### PR TITLE
Implement isatty() for Linux.

### DIFF
--- a/plat/linux/libsys/ioctl.c
+++ b/plat/linux/libsys/ioctl.c
@@ -1,0 +1,11 @@
+#include "libsys.h"
+
+/*
+ * The usual prototype is ioctl(int, unsigned long, ...).  We use a
+ * different prototype to easily get argp, and we don't include any
+ * header file that would declare the usual prototype.
+ */
+int ioctl(int fd, unsigned long request, void *argp)
+{
+	return _syscall(__NR_ioctl, fd, request, argp);
+}

--- a/plat/linux/libsys/isatty.c
+++ b/plat/linux/libsys/isatty.c
@@ -1,13 +1,12 @@
-/* $Source: /cvsroot/tack/Ack/plat/linux386/libsys/isatty.c,v $
- * $State: Exp $
- * $Revision: 1.1 $
+/*
+ * XXX - can't #include <sys/ioctl.h> because libcc.ansi and libsys
+ * both provide it, and we might find the wrong one.
  */
-
-#include <stdlib.h>
-#include <errno.h>
-#include <unistd.h>
+#define TIOCGETD 0x5424
+int ioctl(int fd, unsigned long, ...);
 
 int isatty(int fd)
 {
-	return 0;
+	int line_disc;
+	return 0 <= ioctl(fd, TIOCGETD, &line_disc);
 }


### PR DESCRIPTION
If it understands TIOCGETD, then it is a tty, else it isn't one.  This
seems to help Basic's input statement so I can see the prompt before
I enter my input.
