### PR TITLE
util/ack: use DEFAULT_PLATFORM, allow non-ASCII filenames, other changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ $(BUILDDIR)/build.$(BUILDSYSTEM): first/ackbuilder.lua Makefile $(BUILD_FILES) $
 	@$(LUA) first/ackbuilder.lua \
 		first/build.lua build.lua \
 		--$(BUILDSYSTEM) \
+		DEFAULT_PLATFORM=$(DEFAULT_PLATFORM) \
 		OBJDIR=$(OBJDIR) \
 		BINDIR=$(BINDIR) \
 		LIBDIR=$(LIBDIR) \

--- a/util/ack/ack.1.X
+++ b/util/ack/ack.1.X
@@ -100,7 +100,7 @@ Note: \fIack\fP refuses to overwrite argument \fI.e\fP files.
 .IP \-t
 Preserve all intermediate files.
 If two \fB\-t\fP are used,
-\fIack\fP also preserves core dumps and output of failed transformations.
+\fIack\fP also preserves output of failed transformations.
 
 .IP \-w
 Suppress all warning messages.

--- a/util/ack/ack.h
+++ b/util/ack/ack.h
@@ -75,14 +75,10 @@ char *getvar(const char *);
 
 /* util.c */
 char *ack_basename(const char *);
-void clr_noscan(char *);
 char *skipblank(char *);
 char *firstblank(char *);
 void fatal(const char *, ...);
 void vprint(const char *, ...);
-#ifdef DEBUG
-void prns(const char *);
-#endif
 void fuerror(const char *, ...);
 void werror(const char *, ...);
 void quit(int);

--- a/util/ack/ack.h
+++ b/util/ack/ack.h
@@ -6,6 +6,8 @@
 #define RCS_ACK "$Id$"
 #endif
 
+#include <stdlib.h> /* size_t, free() */
+
 /****************************************************************************/
 /*                      User settable options                               */
 /****************************************************************************/
@@ -61,20 +63,33 @@ typedef struct {
 
 #define p_cont(elem) ((path *)l_content(elem))
 
-/* Return values of setpath() */
-enum f_path { F_OK, F_NOMATCH, F_NOPATH } ;
-
 /* Own routines */
-enum f_path getpath();
-enum f_path scan_end();
-extern void noodstop();
-extern char *getvar();
-extern char *keeps();
-extern char *basename();
-extern char *skipblank();
-extern char *firstblank();
-extern char *getcore();
-extern char *changecore();
+
+/* rmach.c */
+void setlist(char *);
+
+/* svars.c */
+void setsvar(char *, char *);
+void setpvar(char *, char *(*)(void));
+char *getvar(const char *);
+
+/* util.c */
+char *ack_basename(const char *);
+void clr_noscan(char *);
+char *skipblank(char *);
+char *firstblank(char *);
+void fatal(const char *, ...);
+void vprint(const char *, ...);
+#ifdef DEBUG
+void prns(const char *);
+#endif
+void fuerror(const char *, ...);
+void werror(const char *, ...);
+void quit(int);
+char *keeps(const char *);
+#define throws(str)  free(str)
+void *getcore(size_t);
+void *changecore(void *, size_t);
 #define freecore(area)  free(area)
 
 #define DEBUG	1	/* Allow debugging of Ack */

--- a/util/ack/build.lua
+++ b/util/ack/build.lua
@@ -18,12 +18,28 @@ normalrule {
 cprogram {
 	name = "ack",
 	srcs = {
-		"./*.c",
+		"./data.c",
+		"./files.c",
+		"./grows.c",
+		"./list.c",
+		"./main.c",
+		"./rmach.c",
+		"./run.c",
+		"./scan.c",
+		"./svars.c",
+		"./trans.c",
+		"./util.c",
 		"+tables",
 	},
 	deps = {
 		"h+emheaders",
 		"h+local",
+		"./ack.h",
+		"./data.h",
+		"./dmach.h",
+		"./grows.h",
+		"./list.h",
+		"./trans.h",
 	}
 }
 

--- a/util/ack/data.h
+++ b/util/ack/data.h
@@ -48,4 +48,4 @@ EXTERN  path            in;             /* The current single input pathname */
 EXTERN  path            out;            /* The current output pathname */
 EXTERN  path            orig;           /* The original input path */
 EXTERN  char            *p_basename;    /* The current basename */
-EXTERN  char            *p_suffix;      /* The current input suffix */
+EXTERN  const char      *p_suffix;      /* The current input suffix */

--- a/util/ack/files.c
+++ b/util/ack/files.c
@@ -16,7 +16,7 @@
 static char rcs_id[] = "$Id$" ;
 #endif
 
-char *add_u(part,ptr) char *ptr ; {
+static char *add_u(int part, char *ptr) {
 	if ( part>=26 ) {
 		ptr=add_u(part/26-1,ptr) ;
 	}
@@ -24,7 +24,7 @@ char *add_u(part,ptr) char *ptr ; {
 	return ptr+1 ;
 }
 
-char *unique() {
+static char *unique(void) {
 	/* Get the next unique part of the internal filename */
 	static int u_next = 0 ;
 	static char buf[10] ;
@@ -36,7 +36,7 @@ char *unique() {
 	return buf ;
 }
 
-setfiles(phase) register trf *phase ; {
+int setfiles(trf *phase) {
 	/* Set the out structure according to the in structure,
 	   the transformation and some global data */
 	growstring pathname ;
@@ -94,18 +94,7 @@ setfiles(phase) register trf *phase ; {
 	return 1 ;
 }
 
-disc_files(phase) trf *phase ; {
-	path temp ;
-
-	if ( !phase->t_combine ) {
-		file_final(&in) ;
-	} else {
-		disc_inputs(phase) ;
-	}
-	temp=in ; in=out ; out=temp ;
-}
-
-file_final(file) path *file ; {
+static void file_final(path *file) {
 	if ( file->p_path ) {
 		if ( !file->p_keep && t_flag<=1 ) {
 			if ( unlink(file->p_path)!=0 ) {
@@ -119,7 +108,18 @@ file_final(file) path *file ; {
 	file->p_keep=NO ;
 }
 
-disc_inputs(phase) trf *phase ; {
+void disc_files(trf *phase) {
+	path temp ;
+
+	if ( !phase->t_combine ) {
+		file_final(&in) ;
+	} else {
+		disc_inputs(phase) ;
+	}
+	temp=in ; in=out ; out=temp ;
+}
+
+void disc_inputs(trf *phase) {
 	/* Remove all the input files of this phase */
 	/* Only for combiners */
 	register path *l_in ;
@@ -132,7 +132,7 @@ disc_inputs(phase) trf *phase ; {
 	l_clear(&phase->t_inputs) ;
 }
 
-rmfile(file) path *file ; {
+void rmfile(path *file) {
 	/* Remove a file, do not complain when is does not exist */
 	if ( file->p_path ) {
 		if ( t_flag<=1 ) unlink(file->p_path) ;
@@ -143,8 +143,7 @@ rmfile(file) path *file ; {
 	}
 }
 
-void
-rmtemps() {
+void rmtemps(void) {
 	/* Called in case of disaster, always remove the current output file!
 	*/
 	register list_elem *elem ;
@@ -159,7 +158,7 @@ rmtemps() {
 	}
 }
 
-add_input(file,phase) path *file ; trf *phase ; {
+void add_input(path *file, trf *phase) {
 	register path *store ;
 #ifdef DEBUG
 	if ( debug ) {

--- a/util/ack/grows.c
+++ b/util/ack/grows.c
@@ -19,7 +19,7 @@ static char rcs_id[] = "$Id$" ;
 static char rcs_grows[] = RCS_GROWS ;
 #endif
 
-gr_add(id,c) register growstring *id ; char c ; {
+int gr_add(growstring *id, int c) {
 	if ( id->gr_size==id->gr_max) {
 		if ( id->gr_size==0 ) { /* The first time */
 			id->gr_max= 2*GR_MORE ;
@@ -32,8 +32,8 @@ gr_add(id,c) register growstring *id ; char c ; {
 	*(id->gr_string+id->gr_size++)= c ;
 }
 
-gr_cat(id,string) growstring *id ; char *string ; {
-	register char *ptr ;
+int gr_cat(growstring *id, const char *string) {
+	const char *ptr ;
 
 #ifdef DEBUG
 	if ( id->gr_size && *(id->gr_string+id->gr_size-1) ) {
@@ -50,8 +50,7 @@ gr_cat(id,string) growstring *id ; char *string ; {
 	}
 }
 
-void
-gr_throw(id) register growstring *id ; {
+void gr_throw(growstring *id) {
 	/* Throw the string away */
 	if ( id->gr_max==0 ) return ;
 	freecore(id->gr_string) ;
@@ -60,11 +59,11 @@ gr_throw(id) register growstring *id ; {
 	id->gr_size=0 ;
 }
 
-gr_init(id) growstring *id ; {
+void gr_init(growstring *id) {
 	id->gr_size=0 ; id->gr_max=0 ;
 }
 
-char *gr_final(id) growstring *id ; {
+char *gr_final(growstring *id) {
 	/* Throw away the bookkeeping, adjust the string to its final
 	   length and return a pointer to a string to be get rid of with
 	   throws

--- a/util/ack/grows.h
+++ b/util/ack/grows.h
@@ -20,8 +20,8 @@ typedef struct {
 
 /* Routines used */
 
-extern  void    gr_throw() ;    /* To free the core */
-extern  int     gr_add() ;      /* To add one character */
-extern  int     gr_cat() ;      /* concatenate the contents and the string */
-extern  int     gr_init() ;     /* Initialize the bookkeeping */
-extern  char    *gr_final() ;   /* Transform to a stable storage string */
+void     gr_throw(growstring *) ;               /* To free the core */
+int      gr_add(growstring *, int) ;            /* To add one character */
+int      gr_cat(growstring *, const char *) ;   /* To append a string */
+void     gr_init(growstring *) ;        /* Initialize the bookkeeping */
+char    *gr_final(growstring *) ;       /* Move to a stable storage string */

--- a/util/ack/list.c
+++ b/util/ack/list.c
@@ -33,7 +33,7 @@ Routines:
 */
 
 
-l_add(header,string) list_head *header ; char *string ; {
+void l_add(list_head *header, char *string) {
 	register list_elem *new;
 
 	/* NOSTRICT */
@@ -49,7 +49,7 @@ l_add(header,string) list_head *header ; char *string ; {
 	header->ca_last= new ;
 }
 
-l_clear(header) list_head *header ; {
+void l_clear(list_head *header) {
 	register list_elem *old, *next;
 	for ( old=header->ca_first ; old ; old= next ) {
 		next= old->ca_next ;
@@ -59,7 +59,7 @@ l_clear(header) list_head *header ; {
 	header->ca_last = (list_elem *) 0 ;
 }
 
-l_throw(header) list_head *header ; {
+void l_throw(list_head *header) {
 	register list_elem *old, *next;
 	for ( old=header->ca_first ; old ; old= next ) {
 		throws(l_content(*old)) ;

--- a/util/ack/list.h
+++ b/util/ack/list.h
@@ -29,3 +29,7 @@ typedef struct ca_elem list_elem ;         /* The decl. for elements */
 /* To be used for scanning lists, ptr is the running variable */
 #define scanlist(elem,ptr) \
 	for ( ptr= elem ; ptr; ptr= l_next(*ptr) )
+
+void l_add(list_head *, char *);
+void l_clear(list_head *);
+void l_throw(list_head *);

--- a/util/ack/rmach.c
+++ b/util/ack/rmach.c
@@ -47,10 +47,6 @@ static char rcs_dmach[] = RCS_DMACH ;
 #define CALL	"callname"
 #define END     "end"
 
-/* trans.c */
-growstring scanb(const char *) ;
-growstring scanvars(const char *) ;
-
 static void intrf(void) ;
 static void open_in(char *) ;
 static void close_in(void) ;
@@ -108,8 +104,8 @@ static int inoptlist(char *nm) {
 }
 
 static void intrf(void) {
+	/* Read in trf (transformation) */
 	register trf *new ;
-	growstring bline ;
 	int twice ;
 	int name_seen=0 ;
 
@@ -130,20 +126,14 @@ static void intrf(void) {
 		} else
 		if ( strcmp(ty_name,PROG)==0 ) {
 			if ( new->t_prog ) twice=YES ;
-			bline= scanb(bol);                /* Scan for \ */
-                      new->t_prog= gr_final(&bline);
+			new->t_prog= keeps(bol);
 		} else
 		if ( strcmp(ty_name,MAPF)==0 ) {
-			/* First read the mapflags line
-				and scan for backslashes */
-			bline= scanb(bol) ;
-			l_add(&new->t_mapf,gr_final(&bline)) ;
+			l_add(&new->t_mapf,keeps(bol)) ;
 		} else
 		if ( strcmp(ty_name,ARGS)==0 ) {
 			if ( new->t_argd ) twice=YES ;
-			bline= scanb(bol) ;
-			new->t_argd= keeps(gr_start(bline)) ;
-			gr_throw(&bline) ;
+			new->t_argd= keeps(bol) ;
 		} else
 		if ( strcmp(ty_name,STD_IN)==0 ) {
 			if ( new->t_stdin ) twice=YES ;
@@ -242,7 +232,7 @@ static void intrf(void) {
 		register list_elem *elem ;
 		vprint("%s: from %s to %s '%s'\n",
 			new->t_name,new->t_in ? new->t_in : "(null)",new->t_out,new->t_prog) ;
-		vprint("\targs: ") ; prns(new->t_argd) ;
+		vprint("\targs: %s",new->t_argd) ;
 		scanlist( l_first(new->t_mapf), elem ) {
 			vprint("\t%s\n",l_content(*elem)) ;
 		}

--- a/util/ack/rmach.c
+++ b/util/ack/rmach.c
@@ -47,19 +47,21 @@ static char rcs_dmach[] = RCS_DMACH ;
 #define CALL	"callname"
 #define END     "end"
 
-extern growstring scanb();
-extern growstring scanvars();
+/* trans.c */
+growstring scanb(const char *) ;
+growstring scanvars(const char *) ;
 
-int getln() ;
-int getinchar() ;
+static void intrf(void) ;
+static void open_in(char *) ;
+static void close_in(void) ;
+static int getinchar(void) ;
+static int getln(void) ;
+
 static char *ty_name ;
 static char *bol ;
-
-void open_in();
-
 static char *inname ;
 
-setlist(name) char *name ; {
+void setlist(char *name) {
 	/* Name is sought in the internal tables,
 	   if not present, the a file of that name is sought
 	   in first the current and then the EM Lib directory
@@ -92,9 +94,7 @@ setlist(name) char *name ; {
 #endif
 }
 
-static int inoptlist(nm)
-	char *nm ;
-{
+static int inoptlist(char *nm) {
 	register char *p=Optlist ;
 
 	while ( p && *p ) {
@@ -107,7 +107,7 @@ static int inoptlist(nm)
 	return 0;
 }
 
-intrf() {
+static void intrf(void) {
 	register trf *new ;
 	growstring bline ;
 	int twice ;
@@ -234,7 +234,8 @@ intrf() {
 				rts, new->t_rts) ;
 		}
 		rts= new->t_rts ;
-		keephead(rts) ; keeptail(rts) ;
+		l_add(&head_list, rts) ;
+		l_add(&tail_list, rts) ;
 	}
 #ifdef DEBUG
 	if ( debug>=3 ) {
@@ -264,8 +265,7 @@ static  FILE            *infile ;
 static  char            *inptr ;
 char			*em_dir = EM_DIR;
 
-void
-open_in(name) register char *name ; {
+static void open_in(char *name) {
 	register dmach *cmac ;
 
 	gr_init(&rline) ;
@@ -298,12 +298,12 @@ open_in(name) register char *name ; {
 	}
 }
 
-close_in() {
+static void close_in(void) {
 	if ( !incore ) fclose(infile) ;
 	gr_throw(&rline) ;
 }
 
-char *readline() {
+static char *readline(void) {
 	/* Get a line from the input,
 	   return 0 if at end,
 	   The line is stored in a volatile buffer,
@@ -355,7 +355,7 @@ char *readline() {
 	}
 }
 
-int getinchar() {
+static int getinchar(void) {
 	register int token ;
 
 	if ( incore ) {
@@ -369,7 +369,7 @@ int getinchar() {
 	return token ;
 }
 
-int getln() {
+static int getln(void) {
 	register char *c_ptr ;
 
 	do {

--- a/util/ack/run.c
+++ b/util/ack/run.c
@@ -87,8 +87,6 @@ static int run_exec(trf *phase, const char *prog) {
 			}
 		} while ( waitchild!=child) ;
 		if ( status ) {
-			if ( status&0200 && (status&0177)!=SIGQUIT &&
-				t_flag<=1 ) unlink("core") ;
 			switch ( status&0177 ) {
 			case 0 :
 				break ;

--- a/util/ack/run.c
+++ b/util/ack/run.c
@@ -80,7 +80,10 @@ static int run_exec(trf *phase, const char *prog) {
 
 	fflush(stdout) ;
 	fflush(stderr) ;
-	while ( (child=fork())== -1 ) ;
+	child= fork() ;
+	if ( child== - 1) {
+		fatal("Cannot fork %s", prog) ;
+	}
 	if ( child ) {
 		/* The parent */
 		do {

--- a/util/ack/run.c
+++ b/util/ack/run.c
@@ -20,9 +20,6 @@ static char rcs_id[] = "$Id$" ;
 
 #define ARG_MORE  40            /* The size of args chunks to allocate */
 
-/* trans.c */
-growstring scanvars(const char *);
-
 static int run_exec(trf *, const char *);
 static void x_arg(char *);
 
@@ -32,11 +29,9 @@ static unsigned  argmax;        /* The maximum number of arguments so far */
 
 int runphase(trf *phase) {
 	register list_elem *elem ;
-      char *prog ; int result ;
-      growstring bline ;
+	char *prog ; int result ;
 
-      bline=scanvars(phase->t_prog) ;
-      prog=gr_final(&bline) ;
+	prog=phase->t_prog ;
 	if ( v_flag || debug ) {
 		if ( v_flag==1 && !debug ) {
 			vprint("%s",phase->t_name) ;
@@ -70,9 +65,8 @@ int runphase(trf *phase) {
 		x_arg(l_content(*elem)) ;
 	}
 	x_arg( (char *)0 ) ;
-      result=run_exec(phase,prog) ;
-      throws(prog) ;
-      return result ;
+	result=run_exec(phase,prog) ;
+	return result ;
 }
 
 static int run_exec(trf *phase, const char *prog) {

--- a/util/ack/run.c
+++ b/util/ack/run.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include "ack.h"
 #include "list.h"
@@ -19,13 +20,17 @@ static char rcs_id[] = "$Id$" ;
 
 #define ARG_MORE  40            /* The size of args chunks to allocate */
 
-extern growstring scanvars();
+/* trans.c */
+growstring scanvars(const char *);
+
+static int run_exec(trf *, const char *);
+static void x_arg(char *);
 
 static char      **arglist ;    /* The first argument */
 static unsigned  argcount ;     /* The current number of arguments */
 static unsigned  argmax;        /* The maximum number of arguments so far */
 
-int runphase(phase) register trf *phase ; {
+int runphase(trf *phase) {
 	register list_elem *elem ;
       char *prog ; int result ;
       growstring bline ;
@@ -70,10 +75,11 @@ int runphase(phase) register trf *phase ; {
       return result ;
 }
 
-int run_exec(phase,prog) trf *phase ; char *prog ; {
+static int run_exec(trf *phase, const char *prog) {
 	int status, child, waitchild ;
 
-	do_flush();
+	fflush(stdout) ;
+	fflush(stderr) ;
 	while ( (child=fork())== -1 ) ;
 	if ( child ) {
 		/* The parent */
@@ -136,7 +142,7 @@ int run_exec(phase,prog) trf *phase ; char *prog ; {
 	/*NOTREACHED*/
 }
 
-x_arg(string) char *string ; {
+static void x_arg(char *string) {
 	/* Add one execute argument to the argument vector */
 	if ( argcount==argmax ) {
 		if ( argmax==0 ) {

--- a/util/ack/scan.c
+++ b/util/ack/scan.c
@@ -15,9 +15,14 @@
 static char rcs_id[] = "$Id$" ;
 #endif
 
-void try();
+static void start_scan(void);
+static void try(list_elem *, const char *);
+static void scan_found(void);
+static int satisfy(trf *, const char *);
+static enum f_path scan_end(trf **);
+static void find_cpp(void);
 
-enum f_path getpath(first) register trf **first ; {
+enum f_path getpath(trf **first) {
 	/* Try to find a transformation path */
 
 	start_scan();
@@ -49,7 +54,7 @@ static  int     suf_found;      /* Was the suffix at least recognized ? */
 
 /********************       The hard work          ********************/
 
-start_scan() {
+static void start_scan(void) {
 	register list_elem *scan ;
 
 	scanlist(l_first(tr_list),scan) {
@@ -63,8 +68,7 @@ start_scan() {
 	last_ocount= 0 ;
 }
 
-void
-try(f_scan,suffix) list_elem *f_scan; char *suffix; {
+static void try(list_elem *f_scan, const char *suffix) {
 	register list_elem *scan ;
 	register trf  *trafo ;
 	/* Try to find a transformation path starting at f_scan for a
@@ -134,7 +138,7 @@ try(f_scan,suffix) list_elem *f_scan; char *suffix; {
 	}
 }
 
-scan_found() {
+static void scan_found(void) {
 	register list_elem *scan;
 	int ncount, ocount, pcount ;
 
@@ -182,7 +186,7 @@ scan_found() {
 	}
 }
 
-int satisfy(trafo,suffix) register trf *trafo; char *suffix ; {
+static int satisfy(trf *trafo, const char *suffix) {
 	register char *f_char, *l_char ;
 	/* Check whether this transformation is present for
 	   the current machine and the parameter suffix is among
@@ -207,7 +211,7 @@ int satisfy(trafo,suffix) register trf *trafo; char *suffix ; {
 	return 0 ;
 }
 
-enum f_path scan_end(first) trf **first ; {    /* Finalization */
+static enum f_path scan_end(trf **first) {    /* Finalization */
 	/* Return value indicating whether a transformation was found */
 	/* Set the flags for the transformation up to, but not including,
 	   the combiner
@@ -248,7 +252,7 @@ enum f_path scan_end(first) trf **first ; {    /* Finalization */
 	return F_OK ;
 }
 
-find_cpp() {
+static void find_cpp(void) {
 	register list_elem *elem ;
 	scanlist( l_first(tr_list), elem ) {
 		if ( t_cont(*elem)->t_isprep ) {

--- a/util/ack/svars.c
+++ b/util/ack/svars.c
@@ -4,6 +4,7 @@
  *
  */
 
+#include <string.h>
 #include "ack.h"
 
 #ifndef NORCSID
@@ -81,7 +82,7 @@ void setsvar(char *name, char *str) {
 
 	new= newvar(name);
 #ifdef DEBUG
-	if ( debug>=2 ) vprint("%s=%s\n", name, str) ;
+	if ( debug>=2 ) vprint("%s=%s\n", new->v_name, str) ;
 #endif
 	new->v_type= string;
 	new->v_value.v_string= str;
@@ -92,7 +93,7 @@ void setpvar(char *name, char *(*rout)(void)) {
 
 	new= newvar(name);
 #ifdef DEBUG
-	if ( debug>=2 ) vprint("%s= (*%o)()\n",name,rout) ;
+	if ( debug>=2 ) vprint("%s= (*%o)()\n", new->v_name, rout) ;
 #endif
 	new->v_type= routine;
 	new->v_value.v_routine= rout;

--- a/util/ack/svars.c
+++ b/util/ack/svars.c
@@ -44,9 +44,6 @@ static char rcs_id[] = "$Id$" ;
 
 */
 
-extern  char    *getcore();
-extern          fatal();
-
 struct vars {
 	char                            *v_name;
 	enum { routine, string }        v_type;
@@ -60,7 +57,7 @@ struct vars {
 
 static struct vars *v_first ;
 
-static struct vars *newvar(name) char *name; {
+static struct vars *newvar(char *name) {
 	register struct vars *new ;
 
 	for ( new=v_first ; new ; new= new->v_next ) {
@@ -72,14 +69,14 @@ static struct vars *newvar(name) char *name; {
 			return new ;
 		}
 	}
-	new= (struct vars *)getcore( (unsigned)sizeof (struct vars));
+	new= (struct vars *)getcore(sizeof (struct vars));
 	new->v_name= name ;
 	new->v_next= v_first ;
 	v_first= new ;
 	return new ;
 }
 
-setsvar(name,str) char *name, *str ; {
+void setsvar(char *name, char *str) {
 	register struct vars *new ;
 
 	new= newvar(name);
@@ -90,7 +87,7 @@ setsvar(name,str) char *name, *str ; {
 	new->v_value.v_string= str;
 }
 
-setpvar(name,rout) char *name, *(*rout)() ; {
+void setpvar(char *name, char *(*rout)(void)) {
 	register struct vars *new ;
 
 	new= newvar(name);
@@ -101,7 +98,7 @@ setpvar(name,rout) char *name, *(*rout)() ; {
 	new->v_value.v_routine= rout;
 }
 
-char *getvar(name) char *name ; {
+char *getvar(const char *name) {
 	register struct vars *scan ;
 
 	for ( scan=v_first ; scan ; scan= scan->v_next ) {

--- a/util/ack/trans.c
+++ b/util/ack/trans.c
@@ -26,13 +26,15 @@ static int        touch_head= NO ;
 static growstring tail ;
 static int        touch_tail= NO ;
 
-char *headvar(),*tailvar() ;
+static char *headvar(void);
+static char *tailvar(void);
+static void set_Rflag(char *);
+static void condit(growstring *, list_head *, list_head *, char *);
+static int mapflag(list_head *, const char *);
+static int mapexpand(char *, const char *);
+static void getcallargs(trf *);
 
-void condit();
-void doassign();
-void set_Rflag();
-
-int transform(phase) register trf *phase ; {
+int transform(trf *phase) {
 	int ok ;
 
 	if ( !setfiles(phase) ) {
@@ -45,12 +47,13 @@ int transform(phase) register trf *phase ; {
 	/* Free the space occupied by the arguments,
 	   except for the linker, since we are bound to exit soon
 	   and do not foresee further need of memory space */
-	if ( !phase->t_linker ) discardargs(phase) ;
+	if ( !phase->t_linker )
+		l_throw(&phase->t_args) ;
 	disc_files(phase) ;
 	return ok ;
 }
 
-getmapflags(phase) register trf *phase ; {
+void getmapflags(trf *phase) {
 	register path *l_in ;
 	register list_elem *elem ;
 	int scanned ;
@@ -110,16 +113,12 @@ getmapflags(phase) register trf *phase ; {
 }
 
 
-do_Rflag(argp) char *argp ; {
-	l_add(&R_list,argp) ;
-}
-
-char *headvar() {
+static char *headvar(void) {
 	if ( !touch_head) return "" ;
 	return gr_start(head) ;
 }
 
-add_head(str) char *str; {
+void add_head(const char *str) {
 	if ( !touch_head) {
 		gr_init(&head) ;
 		touch_head=YES ;
@@ -127,12 +126,12 @@ add_head(str) char *str; {
 	gr_cat(&head,str) ;
 }
 
-char *tailvar() {
+static char *tailvar(void) {
 	if ( !touch_tail ) return "" ;
 	return gr_start(tail) ;
 }
 
-add_tail(str) char *str ; {
+void add_tail(const char *str) {
 	if ( !touch_tail ) {
 		gr_init(&tail) ;
 		touch_tail=YES ;
@@ -141,7 +140,7 @@ add_tail(str) char *str ; {
 }
 
 
-transini() {
+void transini(void) {
 	register list_elem *elem ;
 	register trf *phase ;
 
@@ -157,8 +156,7 @@ transini() {
 	setpvar(keeps(TAIL),tailvar) ;
 }
 
-void
-set_Rflag(argp) register char *argp ; {
+static void set_Rflag(char *argp) {
 	register char *eos ;
 	register list_elem *prog ;
 	register int length ;
@@ -206,12 +204,12 @@ set_Rflag(argp) register char *argp ; {
 /*                                                                        */
 /**************************************************************************/
 
-growstring scanb(line) char *line ; {
+growstring scanb(const char *line) {
 	/* Scan a line for backslashes, setting the NO_SCAN bit in characters
 	   preceded by a backslash.
 	*/
-	register char *in_c ;
-	register int  token ;
+	const char *in_c ;
+	int token ;
 	growstring result ;
 	enum { TEXT, ESCAPED } state = TEXT ;
 
@@ -237,7 +235,7 @@ growstring scanb(line) char *line ; {
 	return result ;
 }
 
-growstring scanvars(line) char *line ; {
+growstring scanvars(const char *line) {
 	/* Scan a line variable replacements started by S_VAR.
 	   Two sequences exist: S_VAR name E_VAR, S_VAR name A_VAR text E_VAR.
 	   neither name nor text may contain further replacements.
@@ -248,11 +246,10 @@ growstring scanvars(line) char *line ; {
 	   This to allow later recognition in mapflags, where B_SLASH
 	   would be preventing any recognition.
 	*/
-	register char *in_c ;
-	register int  token ;
-	growstring result ;
-	growstring name ;
-	register char *tr ;
+	const char *in_c ;
+	int token ;
+	growstring result, name ;
+	char *tr ;
 	enum { TEXT, FIRST, NAME, SKIP, COPY } state = TEXT ;
 
 	gr_init(&result) ; gr_init(&name) ;
@@ -331,7 +328,7 @@ growstring scanvars(line) char *line ; {
 	return result ;
 }
 
-growstring scanexpr(line) char *line ; {
+static growstring scanexpr(const char *line) {
 	/* Scan a line for conditional or flag expressions,
 	   dependent on the type. The format is
 	   S_EXPR suflist M_EXPR suflist T_EXPR tail C_EXPR
@@ -339,11 +336,9 @@ growstring scanexpr(line) char *line ; {
 	   growstring for futher treatment.
 	   Nesting is not allowed.
 	*/
-	register char *in_c ;
-	char *heads ;
-	register int  token ;
-	growstring sufs, tailval ;
-	growstring result ;
+	const char *in_c, *heads ;
+	int token ;
+	growstring sufs, tailval, result ;
 	static list_head fsuff, lsuff ;
 	enum { TEXT, FDOT, FSUF, LDOT, LSUF, FTAIL } state = TEXT ;
 
@@ -418,10 +413,8 @@ growstring scanexpr(line) char *line ; {
 	return result ;
 }
 
-void
-condit(line,fsuff,lsuff,tailval) growstring *line ;
-	list_head *fsuff, *lsuff;
-	char *tailval ;
+static void condit(growstring *line, list_head *fsuff, list_head *lsuff,
+		   char *tailval)
 {
 	register list_elem *first ;
 	register list_elem *last ;
@@ -446,7 +439,7 @@ condit(line,fsuff,lsuff,tailval) growstring *line ;
 #endif
 }
 
-int mapflag(maplist,cflag) list_head *maplist ; char *cflag ; {
+static int mapflag(list_head *maplist, const char *cflag) {
 	/* Expand a flag expression */
 	/* The flag "cflag" is checked for each of the mapflags.
 	   A mapflag entry has the form
@@ -468,12 +461,9 @@ int mapflag(maplist,cflag) list_head *maplist ; char *cflag ; {
 	return 0 ;
 }
 
-int mapexpand(mapentry,cflag)
-	char *mapentry, *cflag ;
-{
-	register char *star ;
-	register char *ptr ;
-	register char *space ;
+static int mapexpand(char *mapentry, const char *cflag) {
+	const char *star ;
+	char *ptr, *space ;
 	int length ;
 
 	star=strchr(mapentry,STAR) ;
@@ -510,10 +500,9 @@ int mapexpand(mapentry,cflag)
 	return 1 ;
 }
 
-void
-doassign(line,star,length) char *line, *star ; {
+void doassign(const char *line, const char *star, int length) {
 	growstring varval, name, temp ;
-	register char *ptr ;
+	const char *ptr ;
 
 	gr_init(&varval) ;
 	gr_init(&name) ;
@@ -544,7 +533,7 @@ doassign(line,star,length) char *line, *star ; {
 
 #define ISBLANK(c) ( (c)==SPACE || (c)==TAB )
 
-unravel(line,action) char *line ; int (*action)() ; {
+static void unravel(char *line, void (*action)(char *)) {
 	/* Unravel the line, get arguments a la shell */
 	/* each argument is handled to action */
 	/* The input string is left intact */
@@ -581,7 +570,7 @@ unravel(line,action) char *line ; int (*action)() ; {
 	}
 }
 
-char *c_rep(string,place,rep) char *string, *place, *rep ; {
+static char *c_rep(char *string, char *place, char *rep) {
 	/* Produce a string in stable storage produced from 'string'
 	   with the character at place replaced by rep
 	*/
@@ -605,8 +594,7 @@ char *c_rep(string,place,rep) char *string, *place, *rep ; {
 static list_head *curargs ;
 static list_head *comb_args ;
 
-void
-addargs(string) char *string ; {
+static void addargs(char *string) {
 	register char *temp, *repc ;
 	register list_elem *elem ;
 
@@ -653,7 +641,7 @@ addargs(string) char *string ; {
 	l_add(curargs,temp) ;
 }
 
-getcallargs(phase) register trf *phase ; {
+static void getcallargs(trf *phase) {
 	growstring arg1, arg2 ;
 
 	arg1= scanvars(phase->t_argd) ;
@@ -669,8 +657,4 @@ getcallargs(phase) register trf *phase ; {
 	if (phase->t_combine) comb_args = &phase->t_inputs ;
 	unravel( gr_start(arg2), addargs ) ;
 	gr_throw(&arg2) ;
-}
-
-discardargs(phase) register trf *phase ; {
-	l_throw(&phase->t_args) ;
 }

--- a/util/ack/trans.h
+++ b/util/ack/trans.h
@@ -44,3 +44,26 @@ struct transform {
 } ;
 
 #define t_cont(elem) ((trf *)l_content(elem))
+
+/* files.c */
+int setfiles(trf *);
+void disc_files(trf *);
+void disc_inputs(trf *);
+void rmfile(path *);
+void rmtemps(void);
+void add_input(path *, trf *);
+
+/* run.c */
+int runphase(trf *);
+
+/* scan.c */
+enum f_path { F_OK, F_NOMATCH, F_NOPATH } ;
+enum f_path getpath(trf **);
+
+/* trans.c */
+int transform(trf *);
+void getmapflags(trf *);
+void add_head(const char *);
+void add_tail(const char *);
+void transini(void);
+void doassign(const char *, const char *, int);

--- a/util/ack/util.c
+++ b/util/ack/util.c
@@ -32,15 +32,11 @@ extern  int     n_error;
 # define STDOUT stderr
 #endif
 
-void fuerror(const char* fmt, ...);
-void werror(const char* fmt, ...);
-
-char *basename(string) char *string ; {
+char *ack_basename(const char *string) {
 	static char retval[256] ;
-	char *last_dot, *last_start ;
-	register char *store;
-	register char *fetch ;
-	register int ctoken ;
+	const char *last_dot, *last_start, *fetch ;
+	char *store ;
+	int ctoken ;
 
 	last_dot= (char *)0 ;
 	last_start= string ;
@@ -65,21 +61,21 @@ out:
 	return retval ;
 }
 
-clr_noscan(str) char *str ; {
+void clr_noscan(char *str) {
 	register char *ptr ;
 	for ( ptr=str ; *ptr ; ptr++ ) {
 		*ptr&= ~NO_SCAN ;
 	}
 }
 
-char *skipblank(str) char *str ; {
+char *skipblank(char *str) {
 	register char *ptr ;
 
 	for ( ptr=str ; *ptr==SPACE || *ptr==TAB ; ptr++ ) ;
 	return ptr ;
 }
 
-char *firstblank(str) char *str ; {
+char *firstblank(char *str) {
 	register char *ptr ;
 
 	for ( ptr=str ; *ptr && *ptr!=SPACE && *ptr!=TAB ; ptr++ ) ;
@@ -110,7 +106,7 @@ void vprint(const char* fmt, ...)
 }
 
 #ifdef DEBUG
-prns(s) register char *s ; {
+void prns(const char *s) {
 	for ( ; *s ; s++ ) {
 		putc((*s&0377)&~NO_SCAN,STDOUT) ;
 	}
@@ -153,48 +149,36 @@ void error(const char *fmt, ...) {
 	va_end(ap);
 }
 
-do_flush() {
-	fflush(stdout) ;
-	fflush(stderr) ;
-}
-
-void
-noodstop() {
-	quit(-3) ;
-}
-
-quit(code) {
+void quit(int code) {
 	rmtemps();
 	exit(code);
 }
+
 /******
 	char *keeps(string)
 		Keep the string in stable storage.
 	throws(string)
 		Remove the string stored by keep from stable storage.
+		throws() is now a macro in ack.h.
 ***********/
 
-char *keeps(str) char *str ; {
+char *keeps(const char *str) {
 	register char *result ;
 	result= getcore( (unsigned)(strlen(str)+1) ) ;
 	if ( !result ) fatal("Out of core") ;
 	return strcpy(result,str) ;
 }
 
-throws(str) char *str ; {
-	freecore(str) ;
-}
-
-char *getcore(size) unsigned size ; {
-	register char *retptr ;
+void *getcore(size_t size) {
+	void *retptr ;
 
 	retptr= calloc(1,size) ;
 	if ( !retptr ) fatal("Out of memory") ;
 	return retptr ;
 }
 
-char *changecore(ptr,size) char *ptr ; unsigned size ; {
-	register char *retptr ;
+void *changecore(void *ptr, size_t size) {
+	void *retptr ;
 
 	retptr= realloc(ptr,size) ;
 	if ( !retptr ) fatal("Out of memory") ;

--- a/util/ack/util.c
+++ b/util/ack/util.c
@@ -46,9 +46,6 @@ char *ack_basename(const char *string) {
 		case '/'     : last_start=fetch+1 ; break ;
 		case  0      : goto out ;
 		}
-		if ( !isascii(ctoken) || !isprint(ctoken) ) {
-			werror("non-ascii characters in argument %s",string) ;
-		}
 	}
 out:
 	if ( ! *last_start ) fuerror("empty filename \"%s\"",string) ;
@@ -59,13 +56,6 @@ out:
 	}
 	*store= 0 ;
 	return retval ;
-}
-
-void clr_noscan(char *str) {
-	register char *ptr ;
-	for ( ptr=str ; *ptr ; ptr++ ) {
-		*ptr&= ~NO_SCAN ;
-	}
 }
 
 char *skipblank(char *str) {
@@ -104,15 +94,6 @@ void vprint(const char* fmt, ...)
 	vfprintf(STDOUT, fmt, ap);
 	va_end(ap);
 }
-
-#ifdef DEBUG
-void prns(const char *s) {
-	for ( ; *s ; s++ ) {
-		putc((*s&0377)&~NO_SCAN,STDOUT) ;
-	}
-	putc('\n',STDOUT) ;
-}
-#endif
 
 /* VARARGS1 */
 void fuerror(const char *fmt, ...) {


### PR DESCRIPTION
This pull request is for util/ack, the front end of the compiler.

- Fix the build system to use DEFAULT_PLATFORM and to exclude mktables.c from the ack binary.
- In ack, don't print a string after freeing it, don't retry fork() in a loop, and don't try to remove core dumps.
- Let ack compile files with UTF-8 and other non-ASCII names. My commit 07b04c6 preserves the high bits, but changes how ack parses backslashes in descr files. Our descr files only use backslashes to continue lines, and those backslashes work as before.