### PR TITLE
Make Pascal sets work on PowerPC (both ncg and mcg); make Pascal know about 8-bit bytes.

### DIFF
--- a/first/testsummary.sh
+++ b/first/testsummary.sh
@@ -26,6 +26,13 @@ echo "$(echo "$timedout" | wc -w) timed out"
 echo "$(echo "$failed" | wc -w) failed"
 echo ""
 
+if [ "$failed" != "" ]; then
+	echo "Failing test logs:"
+	for t in $failed; do
+		echo $t
+	done
+	exit 1
+fi
 if [ "$failed" != "" -o "$timedout" != "" ]; then
 	echo "Test status: SAD FACE (tests are failing)"
 	exit 1

--- a/lang/pc/comp/LLlex.c
+++ b/lang/pc/comp/LLlex.c
@@ -164,14 +164,10 @@ register int delim;
 				Malloc((unsigned) sizeof(struct string));
 	register char *p;
 	register int len = ISTRSIZE;
-	
+
 	str->s_str = p = Malloc((unsigned int) ISTRSIZE);
 	for( ; ; )	{
 		LoadChar(ch);
-		if( ch & 0200 ) {
-			fatal("non-ascii '\\%03o' read", ch & 0377);
-			/*NOTREACHED*/
-		}
 		if( class(ch) == STNL )	{
 			lexerror("newline in string");
 			LineNumber++;
@@ -310,11 +306,6 @@ again:
 		LoadChar(ch);
 		if( !options['C'] )		/* -C : cases are different */
 			TO_LOWER(ch);
-
-		if( (ch & 0200) && ch != EOI ) {
-			fatal("non-ascii '\\%03o' read", ch & 0377);
-			/*NOTREACHED*/
-		}
 	}
 
 	switch( class(ch) )	{
@@ -420,7 +411,7 @@ again:
 		/* dtrg: removed to allow Pascal programs to access system routines
 		 * (necessary to make them do anything useful). What's this for,
 		 * anyway? */
-		 
+
 #if 0
 		if( buf[0] == '_' ) lexerror("underscore starts identifier");
 #endif
@@ -492,7 +483,7 @@ again:
 				PushBack();
 				goto end;
 			}
-				
+
 		}
 		if( ch == 'e' || ch == 'E' )	{
 			char *tp = np;		/* save position in string */

--- a/lang/pc/comp/type.c
+++ b/lang/pc/comp/type.c
@@ -94,8 +94,8 @@ InitTypes()
 	/* character type
 	*/
 	char_type = standard_type(T_CHAR, 1, (arith) 1);
-	char_type->enm_ncst = 128;	/* only 7 bits ASCII characters */
-	
+	char_type->enm_ncst = 256; /* all bytes */
+
 	/* boolean type
 	*/
 	bool_type = standard_type(T_ENUMERATION, 1, (arith) 1);

--- a/mach/powerpc/libem/ior.s
+++ b/mach/powerpc/libem/ior.s
@@ -3,11 +3,13 @@
 .sect .text
 
 ! Set union.
-!  Stack: ( b a -- a+b )
-!  With r3 = size of set
+!  Stack: ( size b a -- a+b )
 
 .define .ior
 .ior:
+	lwz r3, 0 (sp)
+	addi sp, sp, 4
+
 	mr	r4, sp			! r4 = ptr to set a
 	add	r5, sp, r3		! r5 = ptr to set b
 	rlwinm	r6, r3, 30, 2, 31

--- a/mach/powerpc/libem/rck.s
+++ b/mach/powerpc/libem/rck.s
@@ -1,0 +1,22 @@
+#include "powerpc.h"
+
+.sect .text
+
+! Bounds check. Traps if the value is out of range.
+!  Stack: ( descriptor value -- )
+
+.define .rck
+.rck:
+    lwz r3, 0 (sp)
+    lwz r4, 4 (sp)
+    addi sp, sp, 8
+
+    lwz r5, 0 (r3)
+    cmp cr0, 0, r4, r5
+    bc IFTRUE, LT, .trap_erange
+
+    lwz r5, 4 (r3)
+    cmp cr0, 0, r4, r5
+    bc IFTRUE, GT, .trap_erange
+
+	bclr ALWAYS, 0, 0

--- a/mach/powerpc/libem/set.s
+++ b/mach/powerpc/libem/set.s
@@ -3,11 +3,14 @@
 .sect .text
 
 ! Create singleton set.
-!  Stack: ( -- set )
-!  With r3 = size of set, r4 = bit number
+!  Stack: ( size bitnumber -- set )
 
 .define .set
 .set:
+	lwz     r3, 0 (sp)
+	lwz     r4, 4 (sp)
+	addi    sp, sp, 8
+
 	rlwinm	r7, r3, 30, 2, 31
 	neg	r5, r3
 	add	sp, sp, r5		! allocate set

--- a/mach/powerpc/libem/zer.s
+++ b/mach/powerpc/libem/zer.s
@@ -3,11 +3,13 @@
 .sect .text
 
 ! Create empty set.
-!  Stack: ( -- set )
-!  With r3 = size of set
+!  Stack: ( size -- set )
 
 .define .zer
 .zer:
+	lwz     r3, 0(sp)
+	addi    sp, sp, 4
+
 	rlwinm	r7, r3, 30, 2, 31
 	addi	r4, r0, 0		! r4 = zero
 	neg	r5, r3

--- a/mach/powerpc/ncg/table
+++ b/mach/powerpc/ncg/table
@@ -1503,18 +1503,14 @@ PATTERNS
 			yields {OR_RC, %2, lo(%1.val)}
 
 	pat ior defined($1)                /* OR set */
-		with STACK
-			kills ALL
-			gen
-				move {CONST, $1}, R3
-				bl {LABEL, ".ior"}
+		leaving
+			loc $1
+			cal ".ior"
 
 	/* OR set (variable), used in lang/m2/libm2/LtoUset.e */
 	pat ior !defined($1)
-		with GPR3 STACK
-			kills ALL
-			gen
-				bl {LABEL, ".ior"}
+		leaving
+			cal ".ior"
 
 	pat xor $1==4                      /* XOR word */
 		with REG REG
@@ -1572,12 +1568,10 @@ PATTERNS
 		leaving
 			loc 0
 
-	pat zer defined($1)	   	   /* Create empty set */
-		with STACK
-			kills ALL
-			gen
-				move {CONST, $1}, R3
-				bl {LABEL, ".zer"}
+	pat zer defined($1)	   	           /* Create empty set */
+		leaving
+			loc $1
+			cal ".zer"
 
 	pat sli $1==4                      /* Shift left (second << top) */
 		with CONST_ALL GPR
@@ -1655,27 +1649,19 @@ PATTERNS
 /* Sets */
 
 	pat set defined($1)                /* Create singleton set */
-		with GPR4 STACK
-			kills ALL
-			gen
-				move {CONST, $1}, R3
-				bl {LABEL, ".set"}
+		leaving
+			loc $1
+			cal ".set"
 
 	/* Create set (variable), used in lang/m2/libm2/LtoUset.e */
 	pat set !defined($1)
-		with GPR3 GPR4 STACK
-			kills ALL
-			gen
-				bl {LABEL, ".set"}
+		leaving
+			cal ".set"
 
 	pat inn defined($1)                /* Test for set bit */
-		with STACK
-			kills ALL
-			uses REG
-			gen
-				li32 %a, {CONST, $1}
-				stwu %a, {GPRINDIRECT, SP, 0-4}
-				bl {LABEL, ".inn"}
+		leaving
+			loc $1
+			cal ".inn"
 
 
 /* Boolean resolutions */
@@ -2065,6 +2051,16 @@ PATTERNS
 		leaving
 			loc $1
 			ass 4
+
+	pat lae rck $2==4                  /* Range check */
+		with GPR
+			uses CR0
+			gen
+				cmpli %a, {CONST, 0}, %1, {CONST, rom($1, 1)}
+				bc IFTRUE, LT, {LABEL, ".trap_erange"}
+				cmpli %a, {CONST, 0}, %1, {CONST, rom($1, 2)}
+				bc IFTRUE, GT, {LABEL, ".trap_erange"}
+
 
 
 

--- a/plat/linuxppc/libsys/trap.s
+++ b/plat/linuxppc/libsys/trap.s
@@ -52,43 +52,48 @@ EUNIMPL = 63		! unimplemented em-instruction called
 .trap_ecase:
 	addi r3, r0, ECASE
 	b .trap
-	
+
 .define .trap_earray
 .trap_earray:
 	addi r3, r0, EARRAY
 	b .trap
-	
+
+.define .trap_erange
+.trap_erange:
+	addi r3, r0, ERANGE
+	b .trap
+
 .define .trap
 .trap:
 	cmpi cr0, 0, r3, 15      ! traps >15 can't be ignored
 	bc IFTRUE, LT, 1f
-	
+
 	addi r4, r0, 1
 	rlwnm r4, r4, r3, 0, 31  ! calculate trap bit
 	li32 r5, .ignmask
 	lwz r5, 0(r5)            ! load ignore mask
 	and. r4, r4, r5          ! compare
 	bclr IFFALSE, EQ, 0      ! return if non-zero
-	
+
 1:
 	li32 r4, .trppc
 	lwz r5, 0(r4)            ! load user trap routine
 	or. r5, r5, r5           ! test
 	bc IFTRUE, EQ, fatal     ! if no user trap routine, bail out
-	
+
 	addi r0, r0, 0
 	stw r0, 0(r4)            ! reset trap routine
-	
+
 	mfspr r0, lr
 	stwu r0, -4(sp)          ! save old lr
-	
+
 	stwu r3, -4(sp)
 	mtspr ctr, r5
 	bcctrl ALWAYS, 0, 0      ! call trap routine
-	
+
 	lwz r0, 4(sp)            ! load old lr again
 	addi sp, sp, 8           ! retract over stack usage
-	bclr ALWAYS, 0, 0        ! return 
+	bclr ALWAYS, 0, 0        ! return
 
 fatal:
 	addi r3, r0, 1
@@ -96,7 +101,7 @@ fatal:
 	addi r5, r0, 6
 	addi r0, r0, 4           ! write()
 	sc 0
-	
+
 	addi r0, r0, 1           ! exit()
 	sc 0
 

--- a/plat/qemuppc/libsys/trap.s
+++ b/plat/qemuppc/libsys/trap.s
@@ -49,10 +49,14 @@ EUNIMPL = 63		! unimplemented em-instruction called
 .define .trap_ecase
 .trap_ecase:
 	b .trp
-	
+
 .define .trap_earray
 .trap_earray:
 	b .trp
+
+.define .trap_erange
+.trap_erange:
+	b .trap
 
 .define .trp
 .define .trap
@@ -66,4 +70,3 @@ EUNIMPL = 63		! unimplemented em-instruction called
 	li32 r4, .trppc
 	stw r3, 0(r4)
 	bclr ALWAYS, 0, 0		! return
-	

--- a/tests/plat/charsignedness_p.p
+++ b/tests/plat/charsignedness_p.p
@@ -1,0 +1,28 @@
+#
+(*$U+ -- enables underscores in identifiers *)
+
+program markrelease;
+
+type
+    charset = set of char;
+
+var
+    s : charset;
+    i : integer;
+
+procedure finished;
+    extern;
+
+procedure fail(line: integer);
+    extern;
+
+#define ASSERT(cond) \
+    if (not (cond)) then fail(__LINE__)
+
+begin
+    s := [];
+    for i := 0 to 255 do
+        s := s + [chr(i)];
+
+    finished
+end.

--- a/tests/plat/newdispose_p.p
+++ b/tests/plat/newdispose_p.p
@@ -9,13 +9,13 @@ type
 var
     ptr1 : iptr;
     ptr2 : iptr;
-    
+
 procedure finished;
     extern;
 
 procedure fail(line: integer);
     extern;
-    
+
 #define ASSERT(cond) \
     if (not (cond)) then fail(__LINE__)
 

--- a/tests/plat/pascalsets_p.p
+++ b/tests/plat/pascalsets_p.p
@@ -1,7 +1,7 @@
 #
 (*$U+ -- enables underscores in identifiers *)
 
-program markrelease;
+program pascalsets;
 
 type
     charset = set of char;


### PR DESCRIPTION
This:

- changes the Pascal compiler so that it considers chars to be 8-bits wide, rather than 7
- adds a simple test for Pascal sets
- updates the PowerPC ncg and mcg backends so that enough set operations work for the test to pass