### PR TITLE
mach/proto/as: allow more tokens

### DIFF
--- a/mach/proto/as/comm0.h
+++ b/mach/proto/as/comm0.h
@@ -8,7 +8,21 @@
  * All preprocessor based options/constants/functions
  */
 
-#include <stdint.h>
+#ifdef _include
+_include	<ctype.h>
+_include	<signal.h>
+_include	<stdint.h>
+_include	<stdio.h>
+_include	<stdlib.h>
+_include	<string.h>
+#else
+#include	<ctype.h>
+#include	<signal.h>
+#include	<stdint.h>
+#include	<stdio.h>
+#include	<stdlib.h>
+#include	<string.h>
+#endif
 
 /* ========== ON/OFF options (use #define in mach0.c) ========== */
 
@@ -80,23 +94,16 @@ separate linker only possible if relocation info produced
 /* ========== Machine independent type declarations ========== */
 
 #ifdef _include
-_include    <stdlib.h>
-_include	<stdio.h>
-_include    <string.h>
-_include	<ctype.h>
-_include	<signal.h>
-#else
-#include    <stdlib.h>
-#include	<stdio.h>
-#include    <string.h>
-#include	<ctype.h>
-#include	<signal.h>
+#ifdef ASLD
+_include	"arch.h"
 #endif
-
+_include	"out.h"
+#else
 #ifdef ASLD
 #include	"arch.h"
 #endif
 #include	"out.h"
+#endif
 
 #if DEBUG == 0
 #define	assert(ex)	/* nothing */
@@ -265,6 +272,3 @@ typedef	struct sect_t	sect_t;
 #define	MACHREL_BWR	(0)
 #endif
 #endif
-
-extern FILE *fopen();   /* some systems don't have this in stdio.h */
-

--- a/mach/proto/as/comm1.h
+++ b/mach/proto/as/comm1.h
@@ -104,21 +104,28 @@ extern struct outhead	outhead;
 extern int	curr_token;
 
 /* forward function declarations */
+/* comm5.c */
+int	 yylex(void);
+void	 putval(int);
+int	 getval(int);
+int	 nextchar(void);
 #ifdef ASLD
-extern char	*readident();
+char	*readident(int);
 #endif
-extern char	*remember();
-extern item_t	*fb_shift();
-extern item_t	*fb_alloc();
-extern item_t	*item_alloc();
-extern item_t	*item_search();
-extern valu_t	load();
-extern FILE	*ffcreat();
-extern FILE	*fftemp();
-
-extern void fatal(const char* s, ...);
-extern void serror(const char* s, ...);
-extern void warning(const char* s, ...);
+int	 hash(char *);
+item_t	*item_search(char *);
+void	 item_insert(item_t *, int);
+item_t	*item_alloc(int);
+item_t	*fb_alloc(int);
+item_t	*fb_shift(int);
+/* comm7.c */
+valu_t	 load();
+char	*remember();
+FILE	*ffcreat();
+FILE	*fftemp();
+void	 fatal(const char *, ...);
+void	 serror(const char *, ...);
+void	 warning(const char *, ...);
 
 /* ========== Machine dependent C declarations ========== */
 

--- a/mach/proto/as/comm5.c
+++ b/mach/proto/as/comm5.c
@@ -11,9 +11,16 @@
 
 extern YYSTYPE	yylval;
 
-void putval();
+static void	readcode(int);
+static int	induo(int);
+static int	inident(int);
+static int	innumber(int);
+static int	instring(int);
+static int	inescape(void);
+static int	infbsym(char *);
 
-yylex()
+int
+yylex(void)
 {
 	register c;
 
@@ -71,7 +78,7 @@ yylex()
 }
 
 void
-putval(c)
+putval(int c)
 {
 	register valu_t v;
 	register n = 0;
@@ -144,7 +151,8 @@ putval(c)
 		putc(*p++, tempfile);
 }
 
-getval(c)
+int
+getval(int c)
 {
 	register n = 0;
 	register valu_t v;
@@ -209,7 +217,8 @@ getval(c)
 
 /* ---------- lexical scan in pass 1 ---------- */
 
-nextchar()
+int
+nextchar(void)
 {
 	register c;
 
@@ -233,7 +242,8 @@ nextchar()
 	return(c);
 }
 
-readcode(n)
+static void
+readcode(int n)
 {
 	register c;
 
@@ -252,8 +262,8 @@ readcode(n)
 	} while (--n);
 }
 
-induo(c)
-register c;
+static int
+induo(int c)
 {
 	static short duo[] = {
 		('='<<8) | '=', OP_EQ,
@@ -277,8 +287,8 @@ register c;
 
 static char name[NAMEMAX+1];
 
-inident(c)
-register  c;
+static int
+inident(int c)
 {
 	register char *p = name;
 	register item_t *ip;
@@ -309,8 +319,7 @@ register  c;
 
 #ifdef ASLD
 char *
-readident(c)
-register c;
+readident(int c)
 {
 	register n = NAMEMAX;
 	register char *p = name;
@@ -326,8 +335,8 @@ register c;
 }
 #endif
 
-innumber(c)
-register c;
+static int
+innumber(int c)
 {
 	register char *p;
 	register radix;
@@ -373,7 +382,8 @@ register c;
 	return(NUMBER);
 }
 
-instring(termc)
+static int
+instring(int termc)
 {
 	register char *p;
 	register c;
@@ -412,7 +422,8 @@ instring(termc)
 	return(STRING);
 }
 
-inescape()
+static int
+inescape(void)
 {
 	register c, j, r;
 
@@ -442,8 +453,8 @@ inescape()
 	return(c);
 }
 
-infbsym(p)
-register char *p;
+static int
+infbsym(char *p)
 {
 	register lab;
 	register item_t *ip;
@@ -469,8 +480,8 @@ ok:
 	return(FBSYM);
 }
 
-hash(p)
-register char *p;
+int
+hash(char *p)
 {
 	register unsigned short h;
 	register c;
@@ -484,8 +495,7 @@ register char *p;
 }
 
 item_t *
-item_search(p)
-char *p;
+item_search(char *p)
 {
 	register h;
 	register item_t *ip;
@@ -503,15 +513,15 @@ done:
 	return(ip);
 }
 
-item_insert(ip, h)
-item_t *ip;
+void
+item_insert(item_t *ip, int h)
 {
 	ip->i_next = hashtab[h];
 	hashtab[h] = ip;
 }
 
 item_t *
-item_alloc(typ)
+item_alloc(int typ)
 {
 	register item_t *ip;
 	static nleft = 0;
@@ -532,8 +542,7 @@ item_alloc(typ)
 }
 
 item_t *
-fb_alloc(lab)
-register lab;
+fb_alloc(int lab)
 {
 	register item_t *ip, *p;
 
@@ -548,8 +557,7 @@ register lab;
 }
 
 item_t *
-fb_shift(lab)
-register lab;
+fb_shift(int lab)
 {
 	register item_t *ip;
 

--- a/mach/proto/as/comm6.c
+++ b/mach/proto/as/comm6.c
@@ -354,8 +354,6 @@ valu_t valu;
 	outname.on_type = type;
 	outname.on_desc = desc;
 	outname.on_valu = valu;
-	if (sizeof(valu) != sizeof(long))
-		outname.on_valu &= ~(((0xFFFFFFFF)<<(4*sizeof(valu_t)))<<(4*sizeof(valu_t)));
 	wr_name(&outname, 1);
 }
 


### PR DESCRIPTION
Remove a gcc warning, fix problems with including <stdint.h>, use prototypes in comm5.c, then change comm5.c to allow more tokens. I need f705339 before I can add more tokens to the PowerPC assembler.