### PR TITLE
unbreak qemuppc

### DIFF
--- a/first/testsummary.sh
+++ b/first/testsummary.sh
@@ -31,7 +31,12 @@ if [ "$failed" != "" ]; then
 	for t in $failed; do
 		echo $t
 	done
-	exit 1
+fi
+if [ "$timedout" != "" ]; then
+	echo "Timed-out test logs:"
+	for t in $timedout; do
+		echo $t
+	done
 fi
 if [ "$failed" != "" -o "$timedout" != "" ]; then
 	echo "Test status: SAD FACE (tests are failing)"

--- a/tests/plat/build.lua
+++ b/tests/plat/build.lua
@@ -58,7 +58,7 @@ definerule("plat_testsuite",
 					"util/build+testrunner"
 				},
 				commands = {
-					"(%{ins[2]} "..e.method.." %{ins[1]} 5 %{ins[3]} || echo @@FAIL) > %{outs}",
+					"%{ins[2]} "..e.method.." %{ins[1]} 5 %{ins[3]} > %{outs}; true",
 				}
 			}
 		end

--- a/tests/plat/build.lua
+++ b/tests/plat/build.lua
@@ -58,7 +58,7 @@ definerule("plat_testsuite",
 					"util/build+testrunner"
 				},
 				commands = {
-					"%{ins[2]} "..e.method.." %{ins[1]} 5 %{ins[3]} > %{outs}; true",
+					"%{ins[2]} "..e.method.." %{ins[1]} 15 %{ins[3]} > %{outs}; true",
 				}
 			}
 		end

--- a/util/mcgg/iburg.c
+++ b/util/mcgg/iburg.c
@@ -1280,6 +1280,7 @@ static void emitinsndata(Rule rules)
 
 						if (!find_child_index(r->pattern, label, &index, &node))
 							label_not_found(r, label);
+						nt = node->op;
 						if (nt->kind == NONTERM)
 						{
 							if (nt->is_fragment)


### PR DESCRIPTION
With these commits, qemuppc (with mcg) builds and passes its tests on my machine (OpenBSD 6.2/amd64, qemu-system-ppc 2.10.0).

qemuppc is disabled by default; I tested this by editing the top build.lua to enable qemuppc.