### PR TITLE
Fix occasional weird behaviour causing compilation failures in b.

### DIFF
--- a/lang/b/compiler/b.h
+++ b/lang/b/compiler/b.h
@@ -47,7 +47,7 @@ struct	hshtab hshtab[HSHSIZ];
 int	hshused;
 int	eof;
 int	peekc;
-char	ctab[128];
+const char* ctab;
 struct	hshtab *bsym;
 struct	hshtab *paraml, *parame;
 int	cval;

--- a/lang/b/compiler/b0.c
+++ b/lang/b/compiler/b0.c
@@ -1287,7 +1287,8 @@ int opdope[] = {
 	000000	/* NAME */
 };
 
-char ctab[128] = {
+const char ctaba[129] = {
+	EOFC, /* -1 */
 	EOFC,	UNKN,	UNKN,	UNKN,	UNKN,	UNKN,	UNKN,	UNKN,
 	LETTER,	SPACE,	NEWLN,	SPACE,	SPACE,	UNKN,	UNKN,	UNKN,
 	UNKN,	UNKN,	UNKN,	UNKN,	UNKN,	UNKN,	UNKN,	UNKN,
@@ -1305,6 +1306,7 @@ char ctab[128] = {
 	LETTER,	LETTER,	LETTER,	LETTER,	LETTER,	LETTER,	LETTER,	LETTER,
 	LETTER,	LETTER,	LETTER,	LBRACE,	OR,	RBRACE,	NOT,	UNKN
 };
+const char* ctab = &ctaba[1]; /* allows indexing with -1 */
 
 /* debug function */
 void printtoken(int tok, FILE *out)


### PR DESCRIPTION
Turned out the parser was using a table lookup to get the character class and wasn't special-casing EOF (-1), resulting in out-of-bounds accesses.