### PR TITLE
Fixes to build emulators, ass, int on OpenBSD

### DIFF
--- a/plat/linux68k/emu/musashi/README.ACK.md
+++ b/plat/linux68k/emu/musashi/README.ACK.md
@@ -1,3 +1,3 @@
-This is a copy of the Karl Stenerud's Musashi m68k emulator, available from
-https://github.com/kstenerud/Musashi.  It's MIT licensed and so is compatible
-with the ACK.
+This is a modified copy of the Karl Stenerud's Musashi m68k emulator,
+available from https://github.com/kstenerud/Musashi.  It's MIT licensed
+and so is compatible with the ACK.

--- a/plat/linux68k/emu/musashi/m68kcpu.c
+++ b/plat/linux68k/emu/musashi/m68kcpu.c
@@ -562,7 +562,6 @@ void m68k_set_instr_hook_callback(void  (*callback)(void))
 	CALLBACK_INSTR_HOOK = callback ? callback : default_instr_hook_callback;
 }
 
-#include <stdio.h>
 /* Set the CPU type. */
 void m68k_set_cpu_type(unsigned int cpu_type)
 {

--- a/plat/pc86/emu/README.md
+++ b/plat/pc86/emu/README.md
@@ -1,4 +1,3 @@
-The x86emu directory contains a copy of the xorg 8086 emulation library from
-the X server. It's distributable under the MIT/X11 license, and so is
-compatible with the ACK.
-
+The x86emu directory contains a modified copy of the xorg 8086 emulation
+library from the X server. It's distributable under the MIT/X11 license,
+and so is compatible with the ACK.

--- a/plat/pc86/emu/x86emu/x86emu/debug.h
+++ b/plat/pc86/emu/x86emu/x86emu/debug.h
@@ -189,7 +189,7 @@ extern "C" {                    /* Use "C" linkage when in C++ mode */
 #endif
 
     extern void x86emu_inc_decoded_inst_len(int x);
-    extern void x86emu_decode_printf(const char *x, ...) _X_ATTRIBUTE_PRINTF(1,2);
+    extern void x86emu_decode_printf(const char *x, ...);
     extern void x86emu_just_disassemble(void);
     extern void x86emu_single_step(void);
     extern void x86emu_end_instr(void);

--- a/plat/pc86/emu/x86emu/x86emu/regs.h
+++ b/plat/pc86/emu/x86emu/x86emu/regs.h
@@ -39,8 +39,6 @@
 #ifndef __X86EMU_REGS_H
 #define __X86EMU_REGS_H
 
-#include <X11/Xfuncproto.h>
-
 /*---------------------- Macros and type definitions ----------------------*/
 
 #ifdef PACK
@@ -331,8 +329,7 @@ extern "C" {                    /* Use "C" linkage when in C++ mode */
 
 /* Function to log information at runtime */
 
-    void printk(const char *fmt, ...)
-        _X_ATTRIBUTE_PRINTF(1, 2);
+    void printk(const char *fmt, ...);
 
 #ifdef  __cplusplus
 }                               /* End of "C" linkage for C++           */

--- a/util/ass/ass00.c
+++ b/util/ass/ass00.c
@@ -369,7 +369,7 @@ end_module() {
 	 */
 
 	align(wordsize) ;
-	setmode(DATA_NUL);
+	set_mode(DATA_NUL);
 	dump(100);
 	enmd_pro();
 	enmd_glo();

--- a/util/ass/ass80.c
+++ b/util/ass/ass80.c
@@ -280,7 +280,7 @@ int icount(size) {
 	return amount ;
 }
 
-setmode(mode) {
+set_mode(mode) {
 
 	if (datamode==mode) {   /* in right mode already */
 		switch ( datamode ) {
@@ -302,8 +302,8 @@ setmode(mode) {
 		default:
 			return ;
 		}
-		setmode(DATA_NUL) ; /* flush current descriptor */
-		setmode(mode) ;
+		set_mode(DATA_NUL) ; /* flush current descriptor */
+		set_mode(mode) ;
 		return;
 	}
 	switch(datamode) {              /* terminate current mode */
@@ -376,7 +376,7 @@ setmode(mode) {
 		ext8(HEADBSS) ;
 		break;
 	default:
-		fatal("Unknown mode in setmode") ;
+		fatal("Unknown mode in set_mode") ;
 	}
 }
 

--- a/util/ass/assci.c
+++ b/util/ass/assci.c
@@ -699,10 +699,10 @@ chkstart() {
 
 	if ( absout ) return ;
 	if ( !oksizes ) fatal("missing size specification") ;
-	setmode(DATA_CONST) ;
+	set_mode(DATA_CONST) ;
 	extconst((cons_t)0) ;
 	databytes= wordsize ;
-	setmode(DATA_REP) ;
+	set_mode(DATA_REP) ;
 	if ( wordsize<ABSSIZE ) {
 		register factor = ABSSIZE/wordsize - 1 ;
 		extadr( (cons_t) factor ) ;
@@ -724,14 +724,14 @@ sizealign(size) cons_t size ; {
 
 align(size) int size ; {
 	while ( databytes%size ) {
-		setmode(DATA_BYTES) ;
+		set_mode(DATA_BYTES) ;
 		ext8(0) ;
 		databytes++ ;
 	}
 }
 
 extconst(n) cons_t n ; {
-	setmode(DATA_CONST);
+	set_mode(DATA_CONST);
 	extword(n);
 }
 
@@ -747,7 +747,7 @@ extbss(n) cons_t n ; {
 		}
 		return ;
 	}
-	setmode(DATA_NUL) ; /* flush descriptor */
+	set_mode(DATA_NUL) ; /* flush descriptor */
 	objsize= valsize();
 	if ( objsize==0 ) {
 		werror("Unexpected end-of-line");
@@ -765,18 +765,18 @@ extbss(n) cons_t n ; {
 		putval();
 		amount= n/objsize ;
 		if ( amount>1 ) {
-			setmode(DATA_REP);
+			set_mode(DATA_REP);
 			extadr(amount-1) ;
 		}
 	}
 	else {
 		n = (n + wordsize - 1) / wordsize;
 		while (n > MAXBYTE) {
-			setmode(DATA_BSS);
+			set_mode(DATA_BSS);
 			ext8(MAXBYTE);
 			n -= MAXBYTE;
 		}
-		setmode(DATA_BSS);
+		set_mode(DATA_BSS);
 		ext8((int) n);
 	}
 }
@@ -787,7 +787,7 @@ extloc(lbp) register locl_t *lbp; {
 	 * assemble a pointer constant from a local label.
 	 * For example  con *1
 	 */
-	setmode(DATA_IPTR);
+	set_mode(DATA_IPTR);
 	data_reloc( chp_cast lbp,dataoff,RELLOC);
 	extadr((cons_t)0);
 }
@@ -800,7 +800,7 @@ extglob(agbp,off) glob_t *agbp; cons_t off; {
 	 * Various relocation has to be prepared here in some cases
 	 */
 	gbp=agbp;
-	setmode(DATA_DPTR);
+	set_mode(DATA_DPTR);
 	if ( gbp->g_status&DEF ) {
 		extadr(gbp->g_val.g_addr+off);
 	} else {
@@ -813,7 +813,7 @@ extpro(aprp) proc_t *aprp; {
 	/*
 	 * generate a addres that is defined by a procedure descriptor.
 	 */
-	consiz= ptrsize ; setmode(DATA_UCON);
+	consiz= ptrsize ; set_mode(DATA_UCON);
 	extarb((int)ptrsize,(long)(aprp->p_num));
 }
 
@@ -825,7 +825,7 @@ extstring() {
 	 * generate data for a string.
 	 */
 	for(n=strlngth,s=string ; n--; ) {
-		setmode(DATA_BYTES) ;
+		set_mode(DATA_BYTES) ;
 		ext8(*s++);
 	}
 	return ;
@@ -839,7 +839,7 @@ extxcon(header) {
 	 * generate data for a floating constant initialized by a string.
 	 */
 
-	setmode(header);
+	set_mode(header);
 	s = string ;
 	for (n=strlngth ; n-- ;) {
 		if ( *s==0 ) error("Zero byte in initializer") ;
@@ -875,7 +875,7 @@ extvcon(header) {
 	 * generate data for a constant initialized by a string.
 	 */
 
-	setmode(header);
+	set_mode(header);
 	if ( consiz>4 ) {
 		error("Size of initializer exceeds loader capability") ;
 	}

--- a/util/int/moncalls.c
+++ b/util/int/moncalls.c
@@ -11,12 +11,10 @@
 
 #include	<sys/types.h>
 #include	<sys/stat.h>
-#if __STDC__
-#include	<time.h>
-#endif
 #include	<sys/times.h>
-
-extern int errno;			/* UNIX error number */
+#include	<errno.h>
+#include	<time.h>
+#include	<unistd.h>
 
 extern int running;			/* from main.c */
 extern int fd_limit;			/* from io.c */
@@ -39,10 +37,7 @@ struct timeb {			/* non-existing; we use an ad-hoc definition */
 #endif	/* BSD4_2 */
 
 #ifdef	SYS_V
-#include	<sys/errno.h>
-#undef		ERANGE			/* collision with trap.h */
 #include	<fcntl.h>
-#include	<time.h>
 #endif	/* SYS_V */
 
 #include	<em_abs.h>
@@ -56,13 +51,6 @@ struct timeb {			/* non-existing; we use an ad-hoc definition */
 #define	OUTPUT		1
 
 #define	DUPMASK		0x40
-
-extern long lseek();
-#ifdef	SYS_V
-extern unsigned int alarm();
-extern long time();
-extern void sync();
-#endif	/* SYS_V */
 
 #define	INT2SIZE	max(wsize, 2L)
 #define	INT4SIZE	max(wsize, 4L)
@@ -548,6 +536,7 @@ moncall()
 		LOG(("@m9 Getpid: succeeded, pid = %d", pid));
 		break;
 
+#ifdef WANT_MOUNT_UMOUNT
 	case 21:			/* Mount */
 
 		dsp1 = pop_ptr();
@@ -587,6 +576,7 @@ moncall()
 			LOG(("@m9 Mount: succeeded, dsp1 = %lu", dsp1));
 		}
 		break;
+#endif
 
 	case 23:			/* Setuid */
 
@@ -612,6 +602,7 @@ moncall()
 		LOG(("@m9 Getuid(part 2): eff uid = %d", userid));
 		break;
 
+#ifdef WANT_STIME
 	case 25:			/* Stime */
 
 		tm = pop_int4();
@@ -632,6 +623,7 @@ moncall()
 			LOG(("@m9 Stime: succeeded, tm = %ld", tm));
 		}
 		break;
+#endif
 
 	case 26:			/* Ptrace */
 

--- a/util/int/sysidf.h
+++ b/util/int/sysidf.h
@@ -25,3 +25,8 @@
  * seems to be the standard that won. --- dtrg */
  
 //#define WANT_SGTTY
+
+/* FIXME: Uncomment to enable these calls in moncalls.c */
+
+//#define WANT_MOUNT_UMOUNT
+//#define WANT_STIME


### PR DESCRIPTION
These changes allow me to build the recently added or enabled code on my OpenBSD 6.3 amd64 machine with gcc 4.9.4 or clang 5.0.1.

The build with gcc 4.9.4 also needs -std=c99 in CFLAGS, because plat/pc86/emu/main.c uses the C99 syntax `for(int i = ...)`. I don't add -std=c99 and don't remove `for(int i = ...)` in this pull request, because most C compilers in 2018 should know C99.