### PR TITLE
Fix sub-word-size type conversions for m68020.

### DIFF
--- a/tests/plat/core/dup_e.e
+++ b/tests/plat/core/dup_e.e
@@ -25,9 +25,6 @@ size
     dup 20        /* 2nd copy */
     lae size
     loi 2
-    loc 2
-    loc EM_WSIZE
-    cuu
     dus EM_WSIZE  /* 3rd copy */
 
     cal $check


### PR DESCRIPTION
This adds the rules to suppress 2->4 and 4->2 bytes size conversions when WORD_SIZE=4. This makes the linux68k tests pass.

Fixes: #97 