### PR TITLE
Two fixes for ack -mpdpv7

### DIFF
--- a/plat/pdpv7/descr
+++ b/plat/pdpv7/descr
@@ -1,24 +1,24 @@
 # $Revision$
 var w=2
-var wa=1
+var wa=2
 var p=2
-var pa=1
+var pa=2
 var s=2
-var sa=1
+var sa=2
 var l=4
-var la=1
+var la=2
 var f=4
-var fa=1
+var fa=2
 var d=8
-var da=1
+var da=2
 var x=8
-var xa=1
+var xa=2
 
 var ARCH=pdp
 var PLATFORM=pdpv7
 var PLATFORMDIR={EM}/share/ack/{PLATFORM}
 var CPP_F=-D__unix
-var ALIGN=-a0:1 -a1:1 -a2:1 -a3:1
+var ALIGN=-a0:2 -a1:2 -a2:2 -a3:2
 
 var C_INCLUDES=-I{PLATFORMDIR}/include -I{EM}/share/ack/include/ansi
 

--- a/plat/pdpv7/libsys/isatty.c
+++ b/plat/pdpv7/libsys/isatty.c
@@ -1,8 +1,8 @@
 int isatty(int fd)
 {
-    char* p;
+    unsigned u;
 
-    if (gtty(fd, &p) < 0)
+    if (ioctl(fd, /*TIOCGETD*/(('t'<<8)|0), &u) < 0)
         return 0;
     return 1;
 }


### PR DESCRIPTION
These two fixes prevent some crashes, so I can run some of the hilo examples in simh-pdp11. I didn't fix everything; I will open a new issue to list the other problems.