### PR TITLE
Prevent ass crashing on error on 64-bit machines.

### DIFF
--- a/util/ass/ass00.h
+++ b/util/ass/ass00.h
@@ -256,3 +256,6 @@ struct  proctab {
 	cons_t  pr_off;         /* distance from pb */
 	cons_t  pr_loc;         /* number of bytes locals */
 };
+
+extern void error(const char* string1, ...);
+extern void werror(const char* string1, ...);

--- a/util/ass/ass80.c
+++ b/util/ass/ass80.c
@@ -4,9 +4,10 @@
  *
  */
 
-#include        "ass00.h"
-#include        "assex.h"
-#include        <em_path.h>
+#include "ass00.h"
+#include "assex.h"
+#include <em_path.h>
+#include <stdarg.h>
 
 #ifndef NORCSID
 static char rcs_id[] = "$Id$" ;
@@ -29,7 +30,7 @@ zero(area,length) char *area; unsigned length ; {
 }
 
 /* VARARGS1 */
-static void pr_error(string1,a1,a2,a3,a4) char *string1 ; {
+static void pr_error(const char* string1, va_list ap) {
 	/*
 	 * diagnostic output
 	 */
@@ -44,20 +45,28 @@ static void pr_error(string1,a1,a2,a3,a4) char *string1 ; {
 		fprintf(stderr,"proc %s, ",pstate.s_curpro->p_name);
 	}
 	fprintf(stderr,"line %d: ",line_num);
-	fprintf(stderr,string1,a1,a2,a3,a4);
+	vfprintf(stderr,string1,ap);
 	fprintf(stderr,"\n");
 }
 
 /* VARARGS1 */
-void error(string1,a1,a2,a3,a4) char *string1 ; {
-	pr_error(string1,a1,a2,a3,a4) ;
+void error(const char* string1, ...)
+{
+	va_list ap;
+	va_start(ap, string1);
+	pr_error(string1, ap);
+	va_end(ap);
 	nerrors++ ;
 }
 
 /* VARARGS1 */
-void werror(string1,a1,a2,a3,a4) char *string1 ; {
+void werror(const char* string1, ...) {
+	va_list ap;
 	if ( wflag ) return ;
-	pr_error(string1,a1,a2,a3,a4) ;
+
+	va_start(ap, string1);
+	pr_error(string1, ap);
+	va_end(ap);
 }
 
 fatal(s) char *s; {


### PR DESCRIPTION
The ass error routines use simple argument lists (`error(string, p1, p2, p3, p4)`) and rely on missing prototypes to fake varargs. This doesn't work on 64-bit machines where pointers occupy two machine words. So, replace with real varargs.
