### PR TITLE
Add tea-ci CI for Windows builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,21 +1,15 @@
 clone:
     depth: 10
 build:
-    linuxonwindows:
         image: teaci/msys32
         pull: true
-        shell: sh
+        shell: $$shell
         commands:
-          - apt update
-          - apt install build-essential bison flex
-          - make
-    cygwin:
-        image: teaci/cygwin32
-        pull: true
-        shell: cygwin32
-        commands:
-          - uname -a
-          - id
-          - C:/cygwin-installer.exe --site http://mirrors.tea-ci.org/cygwin --local-package-dir Z:/tmp/cygwin -W -P ninja
+          - if [ $$arch == sh ]; then apt update; apt install build-essential bison flex; fi
           - make PREFIX=/tmp/acki +ack
+
+matrix:
+    arch:
+      - sh
+      - msys32
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ build:
         shell: sh
         commands:
           - apt update
-          - apt install build-essential ninja
+          - apt install build-essential
           - make
     cygwin:
         image: teaci/cygwin32

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ clone:
 build:
         image: teaci/msys32
         pull: true
-        shell: $$shell
+        shell: $$arch
         commands:
           - if [ $$arch == sh ]; then apt update; apt install build-essential bison flex; fi
           - make PREFIX=/tmp/acki +ack

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ build:
         pull: true
         shell: sh
         commands:
-          - apt install build-essentials ninja
+          - apt install build-essential ninja
           - make
     cygwin:
         image: teaci/cygwin32

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,13 @@
 clone:
     depth: 10
 build:
+    linuxonwindows:
+        image: teaci/msys32
+        pull: true
+        shell: sh
+        commands:
+          - apt install build-essentials ninja
+          - make
     cygwin:
         image: teaci/cygwin32
         pull: true
@@ -10,11 +17,4 @@ build:
           - id
           - C:/cygwin-installer.exe --site http://mirrors.tea-ci.org/cygwin --local-package-dir Z:/tmp/cygwin -W -P ninja
           - make PREFIX=/tmp/acki +ack
-    linuxonwindows:
-        image: teaci/msys32
-        pull: true
-        shell: sh
-        commands:
-          - apt install build-essentials ninja
-          - make
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,5 +3,6 @@ build:
     pull: true
     shell: mingw32
     commands:
+      - pacman -S --needed --noconfirm --noprogressbar ninja
       - make PREFIX=/tmp/acki +ack
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ build:
         pull: true
         shell: $$arch
         commands:
-          - if [ $$arch == sh ]; then apt update; apt install build-essential bison flex; fi
+          - if [ $$arch = sh ]; then apt update; apt install build-essential bison flex; fi
           - make PREFIX=/tmp/acki +ack
 
 matrix:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,6 @@
+build:
+    image: teaci/msys32
+    shell: sh
+    commands:
+      - make PREFIX=/tmp/acki +ack
+

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,5 +11,5 @@ build:
 matrix:
     arch:
       - sh
-      - msys32
+      #- msys32
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,7 @@ build:
         pull: true
         shell: sh
         commands:
+          - apt update
           - apt install build-essential ninja
           - make
     cygwin:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,10 @@
 build:
-    image: teaci/msys32
+    image: teaci/cygwin32
     pull: true
-    shell: mingw32
+    shell: cygwin32
     commands:
-      - pacman -S --needed --noconfirm --noprogressbar ninja
+      - uname -a
+      - id
+      - C:/cygwin-installer.exe --site http://mirrors.tea-ci.org/cygwin --local-package-dir Z:/tmp/cygwin -W -P ninja
       - make PREFIX=/tmp/acki +ack
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,10 +1,20 @@
+clone:
+    depth: 10
 build:
-    image: teaci/cygwin32
-    pull: true
-    shell: cygwin32
-    commands:
-      - uname -a
-      - id
-      - C:/cygwin-installer.exe --site http://mirrors.tea-ci.org/cygwin --local-package-dir Z:/tmp/cygwin -W -P ninja
-      - make PREFIX=/tmp/acki +ack
+    cygwin:
+        image: teaci/cygwin32
+        pull: true
+        shell: cygwin32
+        commands:
+          - uname -a
+          - id
+          - C:/cygwin-installer.exe --site http://mirrors.tea-ci.org/cygwin --local-package-dir Z:/tmp/cygwin -W -P ninja
+          - make PREFIX=/tmp/acki +ack
+    linuxonwindows:
+        image: teaci/msys32
+        pull: true
+        shell: sh
+        commands:
+          - apt install build-essentials ninja
+          - make
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,7 @@
 build:
     image: teaci/msys32
-    shell: sh
+    pull: true
+    shell: mingw32
     commands:
       - make PREFIX=/tmp/acki +ack
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ build:
         shell: sh
         commands:
           - apt update
-          - apt install build-essential
+          - apt install build-essential bison flex
           - make
     cygwin:
         image: teaci/cygwin32


### PR DESCRIPTION
This will automatically build the ACK on Windows,in both msys32 and sh-on-windows environments. No cygwin yet.

The builds are known to fail on msys32 due to missing `brk()`.