### PR TITLE
Allow constants >INT_MAX in mcg

### DIFF
--- a/mach/proto/mcg/mcg.h
+++ b/mach/proto/mcg/mcg.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <assert.h>
+#include <errno.h>
 #include "em_arith.h"
 #include "em_label.h"
 #include "em.h"

--- a/mach/proto/mcg/parse_em.c
+++ b/mach/proto/mcg/parse_em.c
@@ -211,6 +211,19 @@ static void data_block_label(const char* label)
 	}
 }
 
+static arith safe_atol(const char* s)
+{
+	arith result;
+
+	errno = 0;
+	result = strtoul(s, NULL, 0);
+	if (errno == ERANGE)
+		result = strtol(s, NULL, 0);
+	if (errno == ERANGE)
+		fatal("constant '%s' not parseable", s);
+	return result;
+}
+
 static void parse_pseu(void)
 {
 	switch (em.em_opcode)
@@ -255,7 +268,7 @@ static void parse_pseu(void)
 				case ico_ptyp:
 				case uco_ptyp:
                 {
-                    arith val = atol(em.em_string);
+                    arith val = safe_atol(em.em_string);
                     data_int(val, em.em_size, ro);
                     data_block_int(val);
                     break;
@@ -313,7 +326,7 @@ static void parse_pseu(void)
 				case ico_ptyp:
 				case uco_ptyp:
                 {
-                    arith val = atol(em.em_string);
+                    arith val = safe_atol(em.em_string);
                     data_int(val, em.em_size, false);
                     break;
                 }


### PR DESCRIPTION
mcg's constant parsing code was incorrectly handling large constants, and would return them all as INT_MAX (with hilarious results).