### PR TITLE
Move int to $(INSDIR)/bin/int

### DIFF
--- a/util/int/build.lua
+++ b/util/int/build.lua
@@ -102,7 +102,7 @@ cprogram {
 installable {
 	name = "pkg",
 	map = {
-		["$(PLATDEP)/int"] = "+int",
+		["$(INSDIR)/bin/int"] = "+int",
 		["$(INSDIR)/share/man/man1/int.1"] = "./int.1",
 	}
 }


### PR DESCRIPTION
If $(INSDIR)/bin is in PATH, then the user can run both ack(1) and
int(1), like

    $ ack -mem22 -o prog prog.c
    $ int prog