### PR TITLE
Fewer calls to brk() and sbrk()

### DIFF
--- a/util/LLgen/src/main.c
+++ b/util/LLgen/src/main.c
@@ -37,12 +37,10 @@ extern		fatal();
 extern		comfatal();
 extern		copyfile();
 extern void install();
-extern char	*sbrk();
 
 main(argc,argv) register string	argv[]; {
 	register string arg;
 	string libpath();
-	char	*beg_sbrk = 0;
 
 	/* Initialize */
 
@@ -129,8 +127,6 @@ main(argc,argv) register string	argv[]; {
 		argc--;
 	}
 
-	if (verbose) beg_sbrk = sbrk(0);
-
 #ifdef NON_CORRECTING
 	if ((subpars_sim) && (!non_corr)) {
 	    fprintf(stderr,"option -s illegal without -n, turned off\n");
@@ -206,7 +202,6 @@ main(argc,argv) register string	argv[]; {
 		fprintf(stderr, "number of tokens: %d\n", ntokens);
 		fprintf(stderr, "number of term structures: %d\n", nterms);
 		fprintf(stderr, "number of alternation structures: %d\n", nalts);
-		fprintf(stderr, "total memory used: %ld\n", (long)(sbrk(0) - beg_sbrk));
 	}
 	exit(0);
 }

--- a/util/led/archive.c
+++ b/util/led/archive.c
@@ -41,14 +41,18 @@ getsymdeftable()
 
 	count = nran = rd_long(infile);
 	debug("%ld ranlib structs, ", nran, 0, 0, 0);
-	off = hard_alloc(ALLORANL, nran * sizeof(struct ranlib));
+	if (nran > SIZE_MAX / sizeof(struct ranlib))
+		off = BADOFF;	/* nran * size would overflow. */
+	else
+		off = hard_alloc(ALLORANL, nran * sizeof(struct ranlib));
 	if (off == BADOFF)
 		fatal("no space for ranlib structs");
 	ran = (struct ranlib *)address(ALLORANL, off);
 	rd_ranlib(infile, ran, count);
 	nchar = rd_long(infile);
 	debug("%ld ranlib chars\n", nchar, 0, 0, 0);
-	if ((off = hard_alloc(ALLORANL, nchar)) == BADOFF)
+	if (nchar != (size_t)nchar ||
+	    (off = hard_alloc(ALLORANL, nchar)) == BADOFF)
 		fatal("no space for ranlib strings");
 	rd_bytes(infile, address(ALLORANL, off), nchar);
 	ran = (struct ranlib *)address(ALLORANL, (ind_t)0);
@@ -144,7 +148,7 @@ notelib(pos)
 {
 	register ind_t	off;
 
-	if ((off = hard_alloc(ALLOARCH, (long)sizeof(long))) == BADOFF)
+	if ((off = hard_alloc(ALLOARCH, sizeof(long))) == BADOFF)
 		fatal("no space for archive position");
 	*(long *)address(ALLOARCH, off) = pos;
 }

--- a/util/led/finish.c
+++ b/util/led/finish.c
@@ -17,7 +17,6 @@ static char rcsid[] = "$Id$";
 #include "orig.h"
 #include "scan.h"
 
-extern bool	incore;
 extern unsigned short	NLocals;
 extern int	flagword;
 extern struct outname	*searchname();
@@ -127,8 +126,6 @@ handle_relos(head, sects, names)
 	register int		sectindex;
 	register int		nrelo;
 	register char		*emit;
-	extern char		*getemit();
-	extern struct outrelo	*nextrelo();
 	static long zeros[MAXSECT];
 
 	if (incore) {
@@ -169,7 +166,6 @@ handle_relos(head, sects, names)
 				    long sz = sects[sectindex].os_flen;
 				    long sf = 0;
 				    long blksz;
-				    char *getblk();
 
 				    emit = getblk(sz, &blksz, sectindex);
 				    while (sz) {

--- a/util/led/main.c
+++ b/util/led/main.c
@@ -23,7 +23,6 @@ static char rcsid[] = "$Id$";
 #include "orig.h"
 #include "sym.h"
 
-extern bool	incore;
 #ifndef NOSTATISTICS
 int		statistics;
 #endif

--- a/util/led/main.c
+++ b/util/led/main.c
@@ -15,6 +15,7 @@ static char rcsid[] = "$Id$";
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 #include <out.h>
 #include "const.h"
 #include "debug.h"
@@ -36,7 +37,7 @@ static			first_pass();
 static uint32_t		number(const char *);
 static void		setlign(int, uint32_t);
 static void		setbase(int, uint32_t);
-static struct outname	*makename();
+static void		enterundef(const char *, int);
 static			pass1();
 static			evaluate();
 static void		norm_commons();
@@ -129,8 +130,6 @@ first_pass(argv)
 	register char		*argp;
 	int			sectno;
 	int			h;
-	extern int		atoi();
-	extern char		*strchr();
 	extern int		hash();
 	extern struct outname	*searchname();
 
@@ -235,7 +234,7 @@ first_pass(argv)
 				fatal("-u needs symbol name");
 			h = hash(*argv);
 			if (searchname(*argv, h) == (struct outname *)0)
-				entername(makename(*argv), h);
+				enterundef(*argv, h);
 			break;
 		case 'v':
 			Verbose = 1;
@@ -330,17 +329,34 @@ setbase(int sectno, uint32_t base)
 	sect_base[sectno] = base;
 }
 
-static struct outname *
-makename(string)
-	char	*string;
+/*
+ * Do -u name by entering the undefined name in the symbol table.
+ */
+static void
+enterundef(const char *string, int hashval)
 {
-	static struct outname	namebuf;
+	struct outname	namebuf;
+	size_t		len;
+	char		*buf;
 
-	namebuf.on_foff = string - core_position - mems[ALLOMODL].mem_base;
+	/*
+	 * Copy string to ALLOMODL, because entername() uses
+	 * modulptr(namebuf.on_foff) but may move ALLOMODL to make
+	 * room in ALLOGCHR.  It also needs namebuf.on_foff != 0.
+	 */
+	len = strlen(string) + 1;
+	buf = core_alloc(ALLOMODL, 1 + len);
+	if (buf == NULL)
+		fatal("no space for -u %s", string);
+	memcpy(buf + 1, string, len);
+
+	namebuf.on_foff = buf + 1 - modulptr(0);
 	namebuf.on_type = S_UND + S_EXT;
 	namebuf.on_valu = (long)0;
+	entername(&namebuf, hashval);
 
-	return &namebuf;
+	/* buf might have moved; find it again and free it. */
+	core_free(ALLOMODL, modulptr(namebuf.on_foff) - 1);
 }
 
 /*

--- a/util/led/memory.h
+++ b/util/led/memory.h
@@ -4,18 +4,21 @@
  */
 /* $Id$ */
 
+#include <stdbool.h>
+#include <stddef.h>
+
 #define ALLOEMIT	0			/* Section contents. */
 #define ALLORELO	(ALLOEMIT + MAXSECT)	/* Relocation table. */
 #define ALLOLOCL	(ALLORELO + 1)		/* Saved local names. */
 #define ALLOGLOB	(ALLOLOCL + 1)		/* Saved global names. */
 #define ALLOLCHR	(ALLOGLOB + 1)		/* Strings of local names. */
 #define ALLOGCHR	(ALLOLCHR + 1)		/* Strings of global names. */
-#ifdef SYMDEBUG
+#ifdef SYMDBUG
 #define ALLODBUG	(ALLOGCHR + 1)		/* Symbolic debugging info. */
-#else /* SYMDEBUG */
-#define ALLODBUG	ALLOGCHR
-#endif /* SYMDEBUG */
-#define ALLOSYMB	(ALLODBUG + 1)		/* Symbol table. */
+#define ALLOSYMB	(ALLODBUG + 1)
+#else /* SYMDBUG */
+#define ALLOSYMB	(ALLOGCHR + 1)		/* Symbol table. */
+#endif /* SYMDBUG */
 #define ALLOARCH	(ALLOSYMB + 1)		/* Archive positions. */
 #define ALLOMODL	(ALLOARCH + 1)		/* Modules. */
 #define ALLORANL	(ALLOMODL + 1)		/* Ranlib information. */
@@ -23,7 +26,7 @@
 
 #define BADOFF		((ind_t)-1)
 
-typedef long		ind_t;
+typedef size_t		ind_t;
 
 struct memory {
 	char	*mem_base;
@@ -35,13 +38,15 @@ extern struct memory	mems[];
 #define address(piece,offset)	(mems[(piece)].mem_base+(offset))
 #define modulptr(offset)	(mems[ALLOMODL].mem_base+core_position+(offset))
 
-#define int_align(sz)		(((sz)+(sizeof(int)-1))&~(int)(sizeof(int)-1))
+#define int_align(sz)		(((sz)+(sizeof(int)-1))&~(sizeof(int)-1))
 
+extern bool		incore;
 extern ind_t		core_position;
 extern void         init_core(void);
-extern ind_t        hard_alloc(int piece, long size);
-extern ind_t        alloc(int piece, long size);
+extern ind_t        hard_alloc(int piece, size_t size);
+extern ind_t        alloc(int piece, size_t size);
 extern void         dealloc(int piece);
+extern char         *core_alloc(int piece, size_t size);
 extern void         core_free(int piece, char* p);
 extern void         write_bytes(void);
 extern void         namecpy(struct outname* name, unsigned nname, long offchar);

--- a/util/led/memory_layout
+++ b/util/led/memory_layout
@@ -21,10 +21,10 @@
 		-----------------------------------------------
 			Strings of global names *
 		-----------------------------------------------
-#ifdef SYMDEBUG
+#ifdef SYMDBUG
 			Symbolic debugging information
 		-----------------------------------------------
-#endif /* SYMDEBUG */
+#endif /* SYMDBUG */
 			Symbol table *
 		-----------------------------------------------
 			Archive positions *

--- a/util/led/output.c
+++ b/util/led/output.c
@@ -18,7 +18,6 @@ static char rcsid[] = "$Id$";
 static void generate_section_names();
 
 extern struct outhead	outhead;
-extern bool		incore;
 extern int		flagword;
 
 /*
@@ -60,11 +59,10 @@ generate_section_names()
 {
 	register struct outname	*name;
 	register int		sectindex;
-	register long		size;
+	register size_t		size;
 	extern struct outsect	outsect[];
-	extern char		*core_alloc();
 
-	size = (long)outhead.oh_nsect * sizeof(struct outname);
+	size = outhead.oh_nsect * sizeof(struct outname);
 	name = (struct outname *)core_alloc(ALLOGLOB, size);
 	if (name == (struct outname *)0)
 		return;

--- a/util/led/save.c
+++ b/util/led/save.c
@@ -21,9 +21,6 @@ static char rcsid[] = "$Id$";
 #include "const.h"
 #include "memory.h"
 
-extern bool	incore;
-extern char	*core_alloc();
-
 void
 savemagic()
 {
@@ -32,7 +29,7 @@ savemagic()
 	if (!incore)
 		return;
 
-	if ((p = core_alloc(ALLOMODL, (long)sizeof(int))) != (char *)0) {
+	if ((p = core_alloc(ALLOMODL, sizeof(int))) != (char *)0) {
 		*(unsigned short *)p = AALMAG;
 		core_position += sizeof(int);
 	}
@@ -47,7 +44,7 @@ savehdr(hdr)
 	if (!incore)
 		return;
 
-	if ((p=core_alloc(ALLOMODL,(long)sizeof(struct ar_hdr)))!=(char *)0) {
+	if ((p=core_alloc(ALLOMODL, sizeof(struct ar_hdr)))!=(char *)0) {
 		*(struct ar_hdr *)p = *hdr;
 		core_position += int_align(sizeof(struct ar_hdr));
 	}
@@ -66,7 +63,7 @@ savechar(piece, off)
 	register int	piece;
 	register ind_t	off;
 {
-	register long	len;
+	register size_t	len;
 	register ind_t	newoff;
 
 	if (off == (ind_t)0)
@@ -104,7 +101,7 @@ savelocal(name)
 		return;
 
 	new = (struct outname *)
-			core_alloc(ALLOLOCL, (long)sizeof(struct outname));
+			core_alloc(ALLOLOCL, sizeof(struct outname));
 	if (new != (struct outname *)0) {
 		*new = *name;
 		new->on_foff = savindex;

--- a/util/led/scan.h
+++ b/util/led/scan.h
@@ -23,4 +23,6 @@ extern void get_modul(void);
 extern void skip_modul(struct outhead* head);
 extern void startrelo(struct outhead* head);
 extern struct outrelo* nextrelo(void);
+extern char* getemit(struct outhead* head, struct outsect* sects, int sectindex);
+extern char* getblk(long totalsz, long* pblksz, int sectindex);
 extern void endemit(char* emit);

--- a/util/led/sym.c
+++ b/util/led/sym.c
@@ -105,9 +105,9 @@ void entername(struct outname* name, int hashval)
 
 	debug("entername %s %d %x %x", modulptr((ind_t)name->on_foff), hashval, name->on_type, name->on_desc);
 	savindex = savechar(ALLOGCHR, (ind_t)name->on_foff);
-	symindex = hard_alloc(ALLOSYMB, (long)sizeof(struct symbol));
+	symindex = hard_alloc(ALLOSYMB, sizeof(struct symbol));
 	debug("; %ld\n", symindex, 0, 0, 0);
-	namindex = hard_alloc(ALLOGLOB, (long)sizeof(struct outname));
+	namindex = hard_alloc(ALLOGLOB, sizeof(struct outname));
 	if (savindex == BADOFF || symindex == BADOFF || namindex == BADOFF)
 		fatal("symbol table overflow");
 	sym = (struct symbol *)address(ALLOSYMB, symindex);

--- a/util/led/write.c
+++ b/util/led/write.c
@@ -20,7 +20,6 @@ static char rcsid[] = "$Id$";
 extern struct outhead	outhead;
 extern struct outsect	outsect[];
 extern int		flagword;
-extern bool		incore;
 
 wr_fatal()
 {

--- a/util/ncgg/main.c
+++ b/util/ncgg/main.c
@@ -11,16 +11,12 @@ static char rcsid[]= "$Id$";
 #include "extern.h"
 
 char *filename;
-char *beg_sbrk;
-extern char *sbrk();
 
 main(argc,argv) char **argv; {
 	extern int nerrors;
 	extern int code_in_c;
 	extern int tabledebug;
 	extern int verbose;
-
-	beg_sbrk = sbrk(0);
 
 	while (argc >1 && argv[1][0]=='-') {
 		switch(argv[1][1]) {

--- a/util/ncgg/output.c
+++ b/util/ncgg/output.c
@@ -902,7 +902,6 @@ used(resource,use,max) char *resource; {
 }
 
 statistics() {
-	extern char *beg_sbrk,*sbrk();
 	extern int nnodes, maxempatlen,maxrule;
 
 	used("Registers",nregs,MAXREGS);
@@ -926,5 +925,4 @@ statistics() {
 	used("Pat bytes",npatbytes+1,MAXPATBYTES);
 	if (tabledebug)
 		used("Source lines",maxline,MAXSOURCELINES);
-	fprintf(stderr,"%ldK heap used\n",((long) (sbrk(0)-beg_sbrk+1023))/1024);
 }


### PR DESCRIPTION
This pull request switches util/led from brk() to malloc() and realloc(). It also removes the sbrk() calls from LLgen and ncgg. This might help build the ACK on more platforms:

- Cygwin (#88) doesn't have brk(). [Cygwin does have sbrk().](https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=winsup/cygwin/heap.cc;h=18145d21c2423261e93afc11b3c551066090826d;hb=HEAD)
- macOS (#74) has [brk() and sbrk()](https://opensource.apple.com/source/Libc/Libc-1244.30.3/emulated/brk.c.auto.html), but brk() always fails and sbrk() has a limit of 4 megabytes.

In many platforms, malloc() and realloc() can allocate outside the brk area, but I don't know if led ever wanted that much memory.

led's brk allocator needs control of the entire brk area, and would stop working if libc ever allocated anything in the brk area. This seems to be why led's main() disables stdio's buffers on stdin/stdout/stderr, and also why modules/src/object doesn't use stdio to read or write .o files. If stdio would malloc() a buffer in the brk area, then led would probably crash!

After led calls freeze_core(), it wants to resize the ALLOMODL piece without moving the piece to a different address. The brk allocator can do that because it puts ALLOMODL after the other pieces in the brk area. realloc() can't do that; see util/led/memory.c line 294.