### PR TITLE
CPM: Move the standard ret boilerplate into a helper procedure.

### DIFF
--- a/mach/i80/libem/ret.s
+++ b/mach/i80/libem/ret.s
@@ -1,0 +1,14 @@
+.sect .text
+.sect .rom
+.sect .data
+.sect .bss
+.sect .text
+
+.define .ret
+.ret:
+	mov h, b
+	mov l, c
+	sphl
+	pop b
+	ret
+

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -1844,18 +1844,12 @@ pat lfr ret $1==$2				leaving ret 0
 pat ret $1==0
 with STACK
 uses hlreg
-gen move lb,hl
-    sphl.
-    pop lb
-    ret.
+gen jmp {label, ".ret"}
 
 pat ret $1==2
 with dereg STACK
 uses hlreg
-gen move lb,hl
-    sphl.
-    pop lb
-    ret.
+gen jmp {label, ".ret"}
 
 pat ret $1<=8
 with STACK
@@ -1868,10 +1862,7 @@ gen 1:
     inx hl
     dcr a
     jnz {label,1b}
-    move lb,hl
-    sphl.
-    pop lb
-    ret.
+	jmp {label, ".ret"}
 
 /******************************************/
 /* Group 15: Miscellaneous		  */


### PR DESCRIPTION
This saves a little space at the expense of speed in the i80 code generator by commoning out the standard return boilerplate into a helper function. Star Trek goes from 44399 to 44256 bytes.