### PR TITLE
i80: factor out function prologue boilerplate

### DIFF
--- a/mach/i80/libem/pro.s
+++ b/mach/i80/libem/pro.s
@@ -1,0 +1,58 @@
+.sect .text
+.sect .rom
+.sect .data
+.sect .bss
+.sect .text
+
+.define .proword, .probyte
+.define .pro0, .pro2, .pro4
+
+! BC is used as the frame pointer, but HL and DE can be corrupted.
+
+.proword:
+	pop h
+	push b
+	mov e, m
+	inx h
+	mov d, m
+	inx h
+	jmp .pron
+
+.probyte:
+	pop h
+	push b
+	mvi e, 0xff
+	mov d, m
+	inx h
+	jmp .pron
+
+.pro4:
+	pop h
+	push b
+	lxi d, -4
+	jmp .pron
+
+.pro2:
+	pop h
+	push b
+	lxi d, -2
+	jmp .pron
+
+.pro0:
+	pop h
+	push b
+	lxi d, 0
+	! fall through
+.pron:
+	shld .retadr
+	! Copy the current stack pointer to BC.
+	lxi h, 0
+	dad sp
+	mov b, h
+	mov c, l
+	! Calculate the new stack pointer.
+	dad d
+	sphl
+	lhld .retadr
+	pchl
+

--- a/mach/i80/ncg/mach.c
+++ b/mach/i80/ncg/mach.c
@@ -5,7 +5,7 @@
  */
 
 #ifndef NORCSID
-static char rcsid[]=	"$Id$" ;
+static char rcsid[] = "$Id$";
 #endif
 
 /*
@@ -14,80 +14,86 @@ static char rcsid[]=	"$Id$" ;
 
 #include <stdlib.h> /* atol */
 
-void
-con_part(sz,w) register sz; word w; {
+void con_part(sz, w) register sz;
+word w;
+{
 
 	while (part_size % sz)
 		part_size++;
 	if (part_size == 2)
 		part_flush();
-	if (sz == 1) {
+	if (sz == 1)
+	{
 		w &= 0xFF;
 		if (part_size)
 			w <<= 8;
 		part_word |= w;
-	} else {
+	}
+	else
+	{
 		assert(sz == 2);
 		part_word = w;
 	}
 	part_size += sz;
 }
 
-void
-con_mult(sz) word sz; {
+void con_mult(sz) word sz;
+{
 
 	if (argval != 4)
 		fatal("bad icon/ucon size");
-	fprintf(codefile,".data4\t%ld\n",atol(str));
+	fprintf(codefile, ".data4\t%ld\n", atol(str));
 }
 
 #define CODE_GENERATOR
 #define IEEEFLOAT
-#define FL_MSL_AT_LOW_ADDRESS   0
-#define FL_MSW_AT_LOW_ADDRESS   0
-#define FL_MSB_AT_LOW_ADDRESS   0
+#define FL_MSL_AT_LOW_ADDRESS 0
+#define FL_MSW_AT_LOW_ADDRESS 0
+#define FL_MSB_AT_LOW_ADDRESS 0
 #include <con_float>
 
-void
-prolog(nlocals) full nlocals; {
+void prolog(nlocals) full nlocals;
+{
 
-	fprintf(codefile,"\tpush\tb\n\tlxi\th,0\n\tdad\tsp\n\tmov\tb,h\n\tmov\tc,l\n");
-	switch (nlocals) {
-	case 4: fprintf(codefile,"\tpush\th\n");
-	case 2: fprintf(codefile,"\tpush\th\n");
-	case 0: break;
-	default:
-		fprintf(codefile,"\tlxi\th,%d\n\tdad\tsp\n\tsphl\n",-nlocals);
-		break;
+	fprintf(codefile, "\tpush\tb\n\tlxi\th,0\n\tdad\tsp\n\tmov\tb,h\n\tmov\tc,l\n");
+	switch (nlocals)
+	{
+		case 4:
+			fprintf(codefile, "\tpush\th\n");
+		case 2:
+			fprintf(codefile, "\tpush\th\n");
+		case 0:
+			break;
+		default:
+			fprintf(codefile, "\tlxi\th,%d\n\tdad\tsp\n\tsphl\n", -nlocals);
+			break;
 	}
 }
 
-void
-mes(type) word type ; {
-	int argt ;
+void mes(type) word type;
+{
+	int argt;
 
-	switch ( (int)type ) {
-	case ms_ext :
-		for (;;) {
-			switch ( argt=getarg(
-			    ptyp(sp_cend)|ptyp(sp_pnam)|sym_ptyp) ) {
-			case sp_cend :
-				return ;
-			default:
-				strarg(argt) ;
-				fprintf(codefile,".define %s\n",argstr) ;
-				break ;
+	switch ((int)type)
+	{
+		case ms_ext:
+			for (;;)
+			{
+				switch (argt = getarg(ptyp(sp_cend) | ptyp(sp_pnam) | sym_ptyp))
+				{
+					case sp_cend:
+						return;
+					default:
+						strarg(argt);
+						fprintf(codefile, ".define %s\n", argstr);
+						break;
+				}
 			}
-		}
-	default :
-		while ( getarg(any_ptyp) != sp_cend ) ;
-		break ;
+		default:
+			while (getarg(any_ptyp) != sp_cend)
+				;
+			break;
 	}
 }
 
-char *segname[] = {
-	".sect .text",
-	".sect .data",
-	".sect .rom",
-	".sect .bss"
-};
+char* segname[] = { ".sect .text", ".sect .data", ".sect .rom", ".sect .bss" };

--- a/mach/i80/ncg/mach.c
+++ b/mach/i80/ncg/mach.c
@@ -52,22 +52,18 @@ void con_mult(sz) word sz;
 #define FL_MSB_AT_LOW_ADDRESS 0
 #include <con_float>
 
-void prolog(nlocals) full nlocals;
+void prolog(full nlocals)
 {
-
-	fprintf(codefile, "\tpush\tb\n\tlxi\th,0\n\tdad\tsp\n\tmov\tb,h\n\tmov\tc,l\n");
-	switch (nlocals)
-	{
-		case 4:
-			fprintf(codefile, "\tpush\th\n");
-		case 2:
-			fprintf(codefile, "\tpush\th\n");
-		case 0:
-			break;
-		default:
-			fprintf(codefile, "\tlxi\th,%d\n\tdad\tsp\n\tsphl\n", -nlocals);
-			break;
-	}
+	if (nlocals == 0)
+		fprintf(codefile, "\tcall .pro0\n");
+	else if (nlocals == 2)
+		fprintf(codefile, "\tcall .pro2\n");
+	else if (nlocals == 4)
+		fprintf(codefile, "\tcall .pro4\n");
+	else if (nlocals < 0x100)
+		fprintf(codefile, "\tcall .probyte\n\t.data1 %d\n", -nlocals);
+	else
+		fprintf(codefile, "\tcall .proword\n\t.data2 %d\n", -nlocals);
 }
 
 void mes(type) word type;


### PR DESCRIPTION
This commons out the chunky prologue which is generated for each function. It's a bit slower now as there's a function call involved, but saves a decent amount of space.