### PR TITLE
i80: use a helper function for cai.

### DIFF
--- a/mach/i80/libem/pchl.s
+++ b/mach/i80/libem/pchl.s
@@ -1,0 +1,10 @@
+.sect .text
+.sect .rom
+.sect .data
+.sect .bss
+.sect .text
+
+.define .pchl
+.pchl:
+	pchl
+

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -1819,11 +1819,7 @@ gen Call {label,$1}
 pat cai
 with hlreg
 kills ALL
-uses dereg
-gen lxi de,{label,1f}
-    push de
-    pchl.
-    1:
+gen Call {label, ".pchl"}
 
 pat lfr $1==2				yields de
 


### PR DESCRIPTION
This only saves two bytes per invocation, so it's not a major win, but it's much less embarrassing.