### PR TITLE
Experimentally use rst 1 to optimise frame variable loads.

### DIFF
--- a/mach/i80/libem/pro.s
+++ b/mach/i80/libem/pro.s
@@ -21,8 +21,8 @@
 .probyte:
 	pop h
 	push b
-	mvi e, 0xff
-	mov d, m
+	mvi d, 0xff
+	mov e, m
 	inx h
 	jmp .pron
 

--- a/mach/i80/libem/rst.s
+++ b/mach/i80/libem/rst.s
@@ -13,16 +13,19 @@
     shld 0x09
     ret
 
-    ! de = [bc+const2] (remember bc is the frame pointer)
+    ! de = [bc+const1] (remember bc is the frame pointer)
 rst1:
     pop h
-    mov e, m
-    inx h
-    mov d, m
+    mov a, m
     inx h
     push h
-    xchg        ! hl = offset
-    dad b
+
+	mov l, a
+	ral
+	sbb a
+	mov h, a
+
+	dad b
     mov e, m
     inx h
     mov d, m

--- a/mach/i80/libem/rst.s
+++ b/mach/i80/libem/rst.s
@@ -1,0 +1,29 @@
+#
+.sect .text
+.sect .rom
+.sect .data
+.sect .bss
+.sect .text
+
+.define .rst_init
+.rst_init:
+    mvi a, 0xc3     ! jmp <a16>
+    sta 0x08
+    lxi h, rst1
+    shld 0x09
+    ret
+
+    ! de = [bc+const2] (remember bc is the frame pointer)
+rst1:
+    pop h
+    mov e, m
+    inx h
+    mov d, m
+    inx h
+    push h
+    xchg        ! hl = offset
+    dad b
+    mov e, m
+    inx h
+    mov d, m
+    ret

--- a/mach/i80/libem/rst.s
+++ b/mach/i80/libem/rst.s
@@ -9,8 +9,11 @@
 .rst_init:
     mvi a, 0xc3     ! jmp <a16>
     sta 0x08
+    sta 0x10
     lxi h, rst1
     shld 0x09
+    lxi h, rst2
+    shld 0x11
     ret
 
     ! de = [bc+const1] (remember bc is the frame pointer)
@@ -30,3 +33,22 @@ rst1:
     inx h
     mov d, m
     ret
+
+    ! [bc+const1] = de (remember bc is the frame pointer)
+rst2:
+    pop h
+    mov a, m
+    inx h
+    push h
+
+	mov l, a
+	ral
+	sbb a
+	mov h, a
+
+	dad b
+    mov m, e
+    inx h
+    mov m, d
+    ret
+

--- a/mach/i80/ncg/mach.c
+++ b/mach/i80/ncg/mach.c
@@ -4,18 +4,13 @@
  *
  */
 
-#ifndef NORCSID
-static char rcsid[] = "$Id$";
-#endif
-
 /*
  * machine dependent back end routines for the Intel 8080.
  */
 
 #include <stdlib.h> /* atol */
 
-void con_part(sz, w) register sz;
-word w;
+void con_part(int sz, word w)
 {
 
 	while (part_size % sz)

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -245,8 +245,7 @@ pat ldc					yields {const2,highw($1)}
 
 #ifdef USE_I80_RSTS
    pat lol sfit($1, 8)
-      kills hlreg
-      uses hlreg, dereg
+      uses hlreg, areg, dereg
       gen
          rst {const1, 1}
          data1 {const1, $1}
@@ -462,8 +461,8 @@ with dereg				yields de de leaving stl $1
 
 #ifdef USE_I80_RSTS
    pat stl sfit($1, 8)
-	  with dereg
-      kills hlreg, areg
+	   with dereg
+      uses hlreg, areg
       gen
          rst {const1, 2}
          data1 {const1, $1}

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -460,13 +460,23 @@ uses hl_or_de={label,$1}		yields %a
 pat stl lol $1==$2
 with dereg				yields de de leaving stl $1
 
+#ifdef USE_I80_RSTS
+   pat stl sfit($1, 8)
+	  with dereg
+      kills hlreg, areg
+      gen
+         rst {const1, 2}
+         data1 {const1, $1}
+#endif
+
 pat stl
-with dereg
-uses hlreg={const2,$1}
-gen dad lb
-    mov {m},e
-    inx hl
-    mov {m},d
+	with dereg
+	uses hlreg={const2, $1}
+	gen
+		dad lb
+		mov {m}, e
+		inx hl
+		mov {m}, d
 
 pat ste loe $1==$2
 with hlreg				yields hl hl leaving ste $1

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -131,7 +131,7 @@ INSTRUCTIONS
 /* rpe					cost(1, 8).	*/
 /* rpo					cost(1, 8).	*/
    rrc			kills a:cc	cost(1, 4).
-   rst	const1:ro kills a:cc cost(1,11).	
+   rst	const1:ro cost(1,11).	
 /* rz					cost(1, 8).	*/
    sbb	reg1:ro 	kills a:cc	cost(1, 4).
 /* sbi	const1:ro 	kills a:cc	cost(2, 7).	*/
@@ -244,23 +244,23 @@ pat ldc					yields {const2,highw($1)}
 					       {const2,loww($1)}
 
 #ifdef USE_I80_RSTS
-   pat lol
+   pat lol sfit($1, 8)
       kills hlreg
       uses hlreg, dereg
       gen
          rst {const1, 1}
-         data2 {const2, $1}
-      yields de
-#else
-   pat lol
-      uses hlreg={const2, $1}, dereg
-      gen
-         dad lb
-         mov e,{m}
-         inx hl
-         mov d,{m}
+         data1 {const1, $1}
       yields de
 #endif
+
+pat lol
+  uses hlreg={const2, $1}, dereg
+  gen
+	 dad lb
+	 mov e,{m}
+	 inx hl
+	 mov d,{m}
+  yields de
 
 pat loe
 uses hlreg

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -82,6 +82,8 @@ INSTRUCTIONS
 /* cpo	label:ro			cost(3,14).	*/
 /* cz	label:ro			cost(3,14).	*/
 /* daa			kills a:cc	cost(1, 4).	*/
+   data1 ".data1" const1:ro.
+   data2 ".data2" const2:ro.
    dad	b_d_h_sp:ro 	kills hl:cc	cost(1,10).
    dcr	reg+lbreg:rw:cc			cost(1, 5).
    dcr	m:rw:cc				cost(1, 7).
@@ -129,7 +131,7 @@ INSTRUCTIONS
 /* rpe					cost(1, 8).	*/
 /* rpo					cost(1, 8).	*/
    rrc			kills a:cc	cost(1, 4).
-/* rst	const1:ro			cost(1,11).	*/
+   rst	const1:ro kills a:cc cost(1,11).	
 /* rz					cost(1, 8).	*/
    sbb	reg1:ro 	kills a:cc	cost(1, 4).
 /* sbi	const1:ro 	kills a:cc	cost(2, 7).	*/
@@ -241,12 +243,24 @@ pat loc					yields {const2,$1}
 pat ldc					yields {const2,highw($1)}
 					       {const2,loww($1)}
 
-pat lol
-uses hlreg={const2,$1}, dereg
-gen dad lb
-    mov e,{m}
-    inx hl
-    mov d,{m}				yields de
+#ifdef USE_I80_RSTS
+   pat lol
+      kills hlreg
+      uses hlreg, dereg
+      gen
+         rst {const1, 1}
+         data2 {const2, $1}
+      yields de
+#else
+   pat lol
+      uses hlreg={const2, $1}, dereg
+      gen
+         dad lb
+         mov e,{m}
+         inx hl
+         mov d,{m}
+      yields de
+#endif
 
 pat loe
 uses hlreg

--- a/mach/proto/ncg/salloc.c
+++ b/mach/proto/ncg/salloc.c
@@ -34,7 +34,7 @@ int nstab=0;
 
 static void chkstr(string, char *);
 
-string myalloc(size) {
+string myalloc(int size) {
 	string p;
 
 	p = (string) calloc((unsigned)size, 1);

--- a/mach/proto/ncg/types.h
+++ b/mach/proto/ncg/types.h
@@ -44,6 +44,7 @@ void in_init(char *);
 void in_start(void);
 void fillemlines(void);
 void swtxt(void);
+void dopseudo(void);
 /* gencode.c */
 void out_init(char *);
 void out_finish(void);

--- a/plat/cpm/boot.s
+++ b/plat/cpm/boot.s
@@ -48,6 +48,12 @@ begtext:
 
 	lxi sp, stack + STACKSIZE
 
+	! Initialise the rsts (if desired).
+
+	#ifdef USE_I80_RSTS
+		call .rst_init
+	#endif
+
 	! C-ify the command line at 0x0080.
 	
 	lxi h, 0x0080

--- a/plat/cpm/build-pkg.lua
+++ b/plat/cpm/build-pkg.lua
@@ -4,7 +4,10 @@ include("lang/build.lua")
 ackfile {
 	name = "boot",
 	srcs = { "./boot.s" },
-	vars = { plat = "cpm" }
+	vars = {
+		plat = "cpm",
+		["+ackcflags"] = "-DUSE_I80_RSTS",
+	}
 }
 
 build_plat_libs {

--- a/plat/cpm/build-tools.lua
+++ b/plat/cpm/build-tools.lua
@@ -8,6 +8,9 @@ build_as {
 build_ncg {
 	name = "ncg",
 	arch = "i80",
+	vars = {
+		["+cflags"] = "-DUSE_I80_RSTS"
+	}
 }
 
 build_top {

--- a/plat/cpm/emu/dis8080.c
+++ b/plat/cpm/emu/dis8080.c
@@ -343,24 +343,36 @@ static struct insn insns[0x100] =
 
 uint16_t i8080_disassemble(char* buffer, size_t bufsiz, uint16_t pc)
 {
-    uint8_t opcode = i8080_read(pc++);
+    uint8_t opcode = i8080_read(pc);
+	uint8_t p1 = i8080_read(pc+1);
+	uint8_t p2 = i8080_read(pc+2);
     struct insn* insn = &insns[opcode];
     uint16_t value = 0;
+	const char* left = "";
+
+	snprintf(buffer, bufsiz, "%04x : ", pc);
+	pc++;
+
     switch (insn->operand)
     {
         case NOTHING:
+			left = "%02x       : ";
             break;
 
         case CONST8:
-            value = i8080_read(pc++);
+			left = "%02x %02x    : ";
+            value = p1;
+			pc++;
             break;
 
         case CONST16:
-            value = i8080_read(pc++);
-            value |= i8080_read(pc++) << 8;
+			left = "%02x %02x %02x : ";
+            value = p1 | (p2<<8);
+			pc += 2;
             break;
     }
 
-    snprintf(buffer, bufsiz, insn->name, value);
+	snprintf(buffer + 7, bufsiz - 7, left, opcode, p1, p2);
+    snprintf(buffer + 18, bufsiz - 18, insn->name, value);
     return pc;
 }

--- a/plat/cpm/libsys/brk.c
+++ b/plat/cpm/libsys/brk.c
@@ -31,13 +31,25 @@ int brk(void* newend)
 void* sbrk(int increment)
 {
 	char* old;
+	char* new;
 	
 	if (increment == 0)
 		return current;
 		
 	old = current;
-	if (brk(old + increment) < 0)
-		return OUT_OF_MEMORY;
-		
+	new = old + increment;
+
+	if ((increment > 0) && (new <= old))
+		goto out_of_memory;
+	else if ((increment < 0) && (new >= old))
+		goto out_of_memory;
+
+	if (brk(new) < 0)
+		goto out_of_memory;
+
 	return old;
+
+out_of_memory:
+	errno = ENOMEM;
+	return OUT_OF_MEMORY;
 }


### PR DESCRIPTION
Reduces Star Trek from 43892 to 41858 bytes.

This also fixes a bunch of test failures and improves the emulator's debugger somewhat.