### PR TITLE
i80: better and, or, xor, sign extension code.

### DIFF
--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -46,6 +46,7 @@ TOKENS
 
 const1			= { INT num; } 1 num.
 const2			= { INT num; } 2 num.
+smallconst2    = { INT num; } 2 num.
 label			= { ADDR off; } 2 off.
 m			= { } 2 cost(0,3) "m".
 
@@ -54,7 +55,7 @@ SETS
 reg1			= reg + lbreg + m.
 b_d_h_sp		= regpair + stackpointer.
 b_d_h_psw		= regpair + psword.
-immediate		= const2 + label.
+immediate		= smallconst2 + const2 + label.
 src1			= reg.
 src2			= hl_or_de + const2 + label.
 src1or2			= src1 + src2.
@@ -114,7 +115,7 @@ INSTRUCTIONS
    mvi	reg1:wo,const1:ro		cost(2, 7).
 /* nop					cost(1, 3).	*/
    ora	reg1:ro 	kills a:cc	cost(1, 4).
-/* ori	const1:ro 	kills a:cc	cost(2, 7).	*/
+   ori	const1:ro 	kills a:cc	cost(2, 7).
 /* out	const1:ro			cost(2,10).	*/
    pchl					cost(1, 5).
    pop	b_d_h_psw:wo			cost(1,10).
@@ -144,7 +145,7 @@ INSTRUCTIONS
    sui	const1:ro 	kills a:cc	cost(2, 7).
    xchg			kills de hl	cost(1, 4).
    xra	reg1:ro 	kills a:cc	cost(1, 4).
-/* xri	const1:ro 	kills a:cc	cost(2, 7).	*/
+   xri	const1:ro 	kills a:cc	cost(2, 7).
    xthl			kills hl	cost(1,18).
    
 
@@ -225,6 +226,9 @@ gen move %1,%a.2
 
 from hl_or_de				yields %1.2
 
+from smallconst2
+   yields {const2, %1.num}
+
 from const2
 uses hl_or_de
 gen move %1,%a				yields %a.2
@@ -239,7 +243,12 @@ PATTERNS
 /* Group 1: Load instructions                */
 /*********************************************/
 
-pat loc					yields {const2,$1}
+pat loc sfit($1, 8)
+   yields {smallconst2, $1}
+
+pat loc
+   yields {const2, $1}
+   
 pat ldc					yields {const2,highw($1)}
 					       {const2,loww($1)}
 
@@ -485,16 +494,17 @@ with hlreg
 gen shld {label,$1}
 
 pat sil
-with dereg
-uses hlreg={const2,$1}, areg
-gen dad lb
-    mov a,{m}
-    inx hl
-    mov h,{m}
-    mov l,a
-    mov {m},e
-    inx hl
-    mov {m},d
+   with dereg
+   uses hlreg={const2,$1}, areg
+   gen
+      dad lb
+      mov a, {m}
+      inx hl
+      mov h, {m}
+      mov l, a
+      mov {m}, e
+      inx hl
+      mov {m}, d
 
 pat sil lil $1==$2
 with dereg
@@ -1123,22 +1133,62 @@ leaving loc $1 loc $2 cal ".cfu" asp 4+$1 lfr 4
 /*****************************************/
 
 pat and $1==2
-with hl_or_de hl_or_de
-uses areg
-gen mov a,%1.2
-    ana %2.2
-    mov %2.2,a
-    mov a,%1.1
-    ana %2.1
-    mov %2.1,a				yields %2
-with hl_or_de hl_or_de
-uses areg
-gen mov a,%1.2
-    ana %2.2
-    mov %1.2,a
-    mov a,%1.1
-    ana %2.1
-    mov %1.1,a				yields %1
+   with hl_or_de smallconst2
+      uses areg
+      gen
+         mov a, %1.2
+         ani {const1, %2.num & 0xff}
+         mov %1.2, a
+         mvi %1.1, {const1, 0}
+      yields %1
+   with hl_or_de const2
+      uses areg
+      gen
+         mov a, %1.2
+         ani {const1, %2.num & 0xff}
+         mov %1.2, a
+         mov a, %1.1
+         ani {const1, %2.num >> 8}
+         mov %1.1, a
+      yields %1
+   with const2 hl_or_de
+      uses areg
+      gen
+         mov a, %2.2
+         ani {const1, %1.num & 0xff}
+         mov %2.2, a
+         mov a, %2.1
+         ani {const1, %1.num >> 8}
+         mov %2.1, a
+      yields %2
+   with smallconst2 hl_or_de
+      uses areg
+      gen
+         mov a, %2.2
+         ani {const1, %1.num & 0xff}
+         mov %2.2, a
+         mvi %2.1, {const1, 0}
+      yields %2
+   with hl_or_de hl_or_de
+      uses areg
+      gen
+         mov a, %1.2
+         ana %2.2
+         mov %2.2, a
+         mov a, %1.1
+         ana %2.1
+         mov %2.1, a
+      yields %2
+   with hl_or_de hl_or_de
+      uses areg
+      gen
+         mov a,%1.2
+         ana %2.2
+         mov %1.2,a
+         mov a,%1.1
+         ana %2.1
+         mov %1.1,a
+      yields %1
 
 pat and defined($1)
 kills ALL
@@ -1151,22 +1201,60 @@ kills ALL
 gen Call {label,".and"}
 
 pat ior $1==2
-with hl_or_de hl_or_de
-uses areg
-gen mov a,%1.2
-    ora %2.2
-    mov %2.2,a
-    mov a,%1.1
-    ora %2.1
-    mov %2.1,a				yields %2
-with hl_or_de hl_or_de
-uses areg
-gen mov a,%1.2
-    ora %2.2
-    mov %1.2,a
-    mov a,%1.1
-    ora %2.1
-    mov %1.1,a				yields %1
+   with hl_or_de smallconst2
+      uses areg
+      gen
+         mov a, %1.2
+         ori {const1, %2.num & 0xff}
+         mov %1.2, a
+      yields %1
+   with hl_or_de const2
+      uses areg
+      gen
+         mov a, %1.2
+         ori {const1, %2.num & 0xff}
+         mov %1.2, a
+         mov a, %1.1
+         ori {const1, %2.num >> 8}
+         mov %1.1, a
+      yields %1
+   with const2 hl_or_de
+      uses areg
+      gen
+         mov a, %2.2
+         ori {const1, %1.num & 0xff}
+         mov %2.2, a
+         mov a, %2.1
+         ori {const1, %1.num >> 8}
+         mov %2.1, a
+      yields %2
+   with smallconst2 hl_or_de
+      uses areg
+      gen
+         mov a, %2.2
+         ori {const1, %1.num & 0xff}
+         mov %2.2, a
+      yields %2
+   with hl_or_de hl_or_de
+      uses areg
+      gen
+         mov a, %1.2
+         ora %2.2
+         mov %2.2, a
+         mov a, %1.1
+         ora %2.1
+         mov %2.1, a
+      yields %2
+   with hl_or_de hl_or_de
+      uses areg
+      gen
+         mov a,%1.2
+         ora %2.2
+         mov %1.2,a
+         mov a,%1.1
+         ora %2.1
+         mov %1.1,a
+      yields %1
 
 pat ior defined($1)
 kills ALL
@@ -1179,22 +1267,60 @@ kills ALL
 gen Call {label,".ior"}
 
 pat xor $1==2
-with hl_or_de hl_or_de
-uses areg
-gen mov a,%1.2
-    xra %2.2
-    mov %2.2,a
-    mov a,%1.1
-    xra %2.1
-    mov %2.1,a				yields %2
-with hl_or_de hl_or_de
-uses areg
-gen mov a,%1.2
-    xra %2.2
-    mov %1.2,a
-    mov a,%1.1
-    xra %2.1
-    mov %1.1,a				yields %1
+   with hl_or_de smallconst2
+      uses areg
+      gen
+         mov a, %1.2
+         xri {const1, %2.num & 0xff}
+         mov %1.2, a
+      yields %1
+   with hl_or_de const2
+      uses areg
+      gen
+         mov a, %1.2
+         xri {const1, %2.num & 0xff}
+         mov %1.2, a
+         mov a, %1.1
+         xri {const1, %2.num >> 8}
+         mov %1.1, a
+      yields %1
+   with const2 hl_or_de
+      uses areg
+      gen
+         mov a, %2.2
+         xri {const1, %1.num & 0xff}
+         mov %2.2, a
+         mov a, %2.1
+         xri {const1, %1.num >> 8}
+         mov %2.1, a
+      yields %2
+   with smallconst2 hl_or_de
+      uses areg
+      gen
+         mov a, %2.2
+         xri {const1, %1.num & 0xff}
+         mov %2.2, a
+      yields %2
+   with hl_or_de hl_or_de
+      uses areg
+      gen
+         mov a, %1.2
+         xra %2.2
+         mov %2.2, a
+         mov a, %1.1
+         xra %2.1
+         mov %2.1, a
+      yields %2
+   with hl_or_de hl_or_de
+      uses areg
+      gen
+         mov a,%1.2
+         xra %2.2
+         mov %1.2,a
+         mov a,%1.1
+         xra %2.1
+         mov %1.1,a
+      yields %1
 
 pat xor defined($1)
 kills ALL

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -999,49 +999,58 @@ gen xra a
 pat loc loc cii $1==$2
 
 pat loc loc cii $1==2 && $2==4
-with hl_or_de
-uses hl_or_de={const2,0}, areg
-gen mov a,%1.1
-    ora a
-    jp {label,1f}
-    lxi %a,{const2,0-1}
-    1:					yields %a %1
+   with hl_or_de
+      uses hl_or_de, areg
+      gen
+         mov a, %1.1
+         ral.
+         sbb a
+         mov %a.1, a
+         mov %a.2, a
+      yields %a %1
 
 pat loc loc cii $1==4 && $2==2
-with hl_or_de hl_or_de			yields %1
+   with hl_or_de hl_or_de
+      yields %1
 
 pat loc loc cii $1==1 && $2==2
-with reg
-uses reusing %1, areg=%1, hl_or_de
-gen move {const1,0},%b.1
-    move a,%b.2
-    ora a
-    jp {label,1f}
-    mvi %b.1,{const1,255}
-    1:					yields %b
-with hl_or_de
-uses areg=%1.2
-gen move {const1,0},%1.1
-    ora a
-    jp {label,1f}
-    mvi %1.1,{const1,255}
-    1:					yields %1
+   with reg
+      uses reusing %1, areg=%1, hl_or_de
+      gen
+         mov %b.2, a
+         ral.
+         sbb a
+         mov %b.1, a
+      yields %b
+   with hl_or_de
+      uses areg=%1.2
+      gen
+         ral.
+         sbb a
+         mov %1.1, a
+      yields %1
 
 pat loc loc cii $1==1 && $2==4
-with reg
-   uses hlreg
-   gen move %1,l			yields hl
-						leaving loc $1 loc $2 cii
-with hlreg
-   uses dereg, areg
-   gen move {const1,0},%1.1
-       move l,a
-       ora a
-       jp {label,1f}
-       mvi h,{const1,255}
-       1:
-       mov e,h
-       mov d,h				yields de hl
+   with areg
+      uses hl_or_de, hl_or_de
+      gen
+         mov %b.2, a
+         ral.
+         sbb a
+         mov %b.1, a
+         mov %a.2, a
+         mov %a.1, a
+      yields %a %b
+   with hlreg
+      uses dereg, areg
+      gen
+         mov a, l
+         ral.
+         sbb a
+         mov h, a
+         mov e, a
+         mov d, a
+      yields de hl
 
 pat cii
 kills ALL

--- a/mach/proto/ncg/codegen.c
+++ b/mach/proto/ncg/codegen.c
@@ -5,6 +5,7 @@ static char rcsid[] = "$Id$";
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include "param.h"
 #include "tables.h"
 #include "types.h"
@@ -375,7 +376,7 @@ unsigned codegen(byte* codep, int ply, int toplevel, unsigned costlimit, int for
 						cp = findcoerc(tp, &machsets[tokexp[i]]);
 #ifndef NDEBUG
 						if (Debug > 1)
-							fprintf(stderr, "findcoerc returns 0x%x at position %d\n", (unsigned)cp, i);
+							fprintf(stderr, "findcoerc returns %p at position %d\n", cp, i);
 #endif
 						if (cp == 0)
 						{

--- a/tests/plat/core/and_e.e
+++ b/tests/plat/core/and_e.e
@@ -4,15 +4,18 @@
     exp $_m_a_i_n
     pro $_m_a_i_n, 0
 
-	/* And word-sized set */
+three
+	rom 3
+one
+	rom 1
+big
+	rom 256
 
-four
-	rom EM_WSIZE
+	/* And var with var */
 
-	loc 32769
-	loc 1
-	loe four		/* to defeat constant folding */
-	and
+	loe three
+	loe one
+	and EM_WSIZE
 	loc 1
 	cmu EM_WSIZE
 	zeq *1
@@ -22,33 +25,61 @@ four
     asp 4
 1
 
-	/* And triple-word-sized set */
+	/* And var with const */
 
-four_by_three
-	rom EM_WSIZE*3
-
-	loc 32769
-	loc 32770
-	loc 32772
+	loe three
 	loc 1
-	loc 2
-	loc 4
-	loe four_by_three
-	and
-	loc 4
+	and EM_WSIZE
+	loc 1
 	cmu EM_WSIZE
-	zne *2
-	loc 2
-	cmu EM_WSIZE
-	zne *2
+	zeq *2
+
+    loc __LINE__
+    cal $fail
+    asp 4
+2
+
+	/* And const with var */
+
+	loc 3
+	loe one
+	and EM_WSIZE
 	loc 1
 	cmu EM_WSIZE
 	zeq *3
-2
-	loc __LINE__
-	cal $fail
-	asp 4
+
+    loc __LINE__
+    cal $fail
+    asp 4
 3
+
+	/* And var with big const */
+
+	loe big
+	loc 257
+	and EM_WSIZE
+	loc 256
+	cmu EM_WSIZE
+	zeq *4
+
+    loc __LINE__
+    cal $fail
+    asp 4
+4
+
+	/* And big const with var */
+
+	loc 257
+	loe big
+	and EM_WSIZE
+	loc 256
+	cmu EM_WSIZE
+	zeq *5
+
+    loc __LINE__
+    cal $fail
+    asp 4
+5
 
     cal $finished
     end

--- a/tests/plat/core/andv_e.e
+++ b/tests/plat/core/andv_e.e
@@ -1,0 +1,54 @@
+#
+    mes 2, EM_WSIZE, EM_PSIZE
+
+    exp $_m_a_i_n
+    pro $_m_a_i_n, 0
+
+	/* And word-sized set */
+
+four
+	rom EM_WSIZE
+
+	loc 32769
+	loc 1
+	loe four		/* to defeat constant folding */
+	and
+	loc 1
+	cmu EM_WSIZE
+	zeq *1
+
+    loc __LINE__
+    cal $fail
+    asp 4
+1
+
+	/* And triple-word-sized set */
+
+four_by_three
+	rom EM_WSIZE*3
+
+	loc 32769
+	loc 32770
+	loc 32772
+	loc 1
+	loc 2
+	loc 4
+	loe four_by_three
+	and
+	loc 4
+	cmu EM_WSIZE
+	zne *2
+	loc 2
+	cmu EM_WSIZE
+	zne *2
+	loc 1
+	cmu EM_WSIZE
+	zeq *3
+2
+	loc __LINE__
+	cal $fail
+	asp 4
+3
+
+    cal $finished
+    end

--- a/tests/plat/core/cii_e.e
+++ b/tests/plat/core/cii_e.e
@@ -1,0 +1,112 @@
+#
+    mes 2, EM_WSIZE, EM_PSIZE
+
+    exp $_m_a_i_n
+    pro $_m_a_i_n, 0
+
+oneshort
+onebyte
+    rom 1
+moneshort
+    rom 65535
+monebyte
+    rom 255
+
+    /* Positive byte->word */
+
+    loe onebyte
+    loc 1
+    loc EM_WSIZE
+    cii
+    loc 1
+	cmu EM_WSIZE
+	zeq *1
+
+    loc __LINE__
+    cal $fail
+    asp 4
+1
+
+    /* Negative byte->word */
+
+    loe monebyte
+    loc 1
+    loc EM_WSIZE
+    cii
+    loc -1
+	cmu EM_WSIZE
+	zeq *2
+
+    loc __LINE__
+    cal $fail
+    asp 4
+2
+
+#if EM_WSIZE == 2
+    /* Positive byte->dword */
+
+    loe onebyte
+    loc 1
+    loc 4
+    cii
+    loc 0
+    loc 1
+	cmu 4
+	zeq *3
+
+    loc __LINE__
+    cal $fail
+    asp 4
+3
+
+    /* Negative byte->short */
+
+    loe monebyte
+    loc 1
+    loc 4
+    cii
+    loc -1
+    loc -1
+	cmu 4
+	zeq *4
+
+    loc __LINE__
+    cal $fail
+    asp 4
+4
+    /* Positive word->dword */
+
+    loe oneshort
+    loc 2
+    loc 4
+    cii
+    loc 0
+    loc 1
+	cmu 4
+	zeq *5
+
+    loc __LINE__
+    cal $fail
+    asp 4
+5
+
+    /* Negative word->short */
+
+    loe moneshort
+    loc 2
+    loc 4
+    cii
+    loc -1
+    loc -1
+	cmu 4
+	zeq *6
+
+    loc __LINE__
+    cal $fail
+    asp 4
+6
+#endif
+
+    cal $finished
+    end
+

--- a/tests/plat/core/ior_e.e
+++ b/tests/plat/core/ior_e.e
@@ -4,15 +4,16 @@
     exp $_m_a_i_n
     pro $_m_a_i_n, 0
 
-	/* Or word-sized set */
+zero
+	rom 0
+one
+	rom 1
 
-four
-	rom EM_WSIZE
+	/* Or var with var */
 
-	loc 0
-	loc 1
-	loe four		/* to defeat constant folding */
-	ior
+	loe zero
+	loe one
+	ior EM_WSIZE
 	loc 1
 	cmu EM_WSIZE
 	zeq *1
@@ -22,33 +23,61 @@ four
     asp 4
 1
 
-	/* Or triple-word-sized set */
+	/* Or var with const */
 
-four_by_three
-	rom EM_WSIZE*3
-
-	loc 16
-	loc 32
-	loc 64
+	loe zero
 	loc 1
-	loc 2
-	loc 3
-	loe four_by_three
-	ior
-	loc 67
+	ior EM_WSIZE
+	loc 1
 	cmu EM_WSIZE
-	zne *2
-	loc 34
-	cmu EM_WSIZE
-	zne *2
-	loc 17
+	zeq *2
+
+    loc __LINE__
+    cal $fail
+    asp 4
+2
+
+	/* Or const with var */
+
+	loc 0
+	loe one
+	ior EM_WSIZE
+	loc 1
 	cmu EM_WSIZE
 	zeq *3
-2
-	loc __LINE__
-	cal $fail
-	asp 4
+
+    loc __LINE__
+    cal $fail
+    asp 4
 3
+
+	/* Or var with big const */
+
+	loe zero
+	loc 1000
+	ior EM_WSIZE
+	loc 1000
+	cmu EM_WSIZE
+	zeq *4
+
+    loc __LINE__
+    cal $fail
+    asp 4
+4
+
+	/* Or big const with var */
+
+	loc 1000
+	loe one
+	ior EM_WSIZE
+	loc 1001
+	cmu EM_WSIZE
+	zeq *5
+
+    loc __LINE__
+    cal $fail
+    asp 4
+5
 
     cal $finished
     end

--- a/tests/plat/core/iorv_e.e
+++ b/tests/plat/core/iorv_e.e
@@ -1,0 +1,54 @@
+#
+    mes 2, EM_WSIZE, EM_PSIZE
+
+    exp $_m_a_i_n
+    pro $_m_a_i_n, 0
+
+	/* Or word-sized set */
+
+four
+	rom EM_WSIZE
+
+	loc 0
+	loc 1
+	loe four		/* to defeat constant folding */
+	ior
+	loc 1
+	cmu EM_WSIZE
+	zeq *1
+
+    loc __LINE__
+    cal $fail
+    asp 4
+1
+
+	/* Or triple-word-sized set */
+
+four_by_three
+	rom EM_WSIZE*3
+
+	loc 16
+	loc 32
+	loc 64
+	loc 1
+	loc 2
+	loc 3
+	loe four_by_three
+	ior
+	loc 67
+	cmu EM_WSIZE
+	zne *2
+	loc 34
+	cmu EM_WSIZE
+	zne *2
+	loc 17
+	cmu EM_WSIZE
+	zeq *3
+2
+	loc __LINE__
+	cal $fail
+	asp 4
+3
+
+    cal $finished
+    end

--- a/tests/plat/core/xor_e.e
+++ b/tests/plat/core/xor_e.e
@@ -4,16 +4,17 @@
     exp $_m_a_i_n
     pro $_m_a_i_n, 0
 
-	/* Xor word-sized set */
+three
+	rom 3
+one
+	rom 1
 
-four
-	rom EM_WSIZE
+	/* Xor var with var */
 
-	loc 32769
-	loc 1
-	loe four		/* to defeat constant folding */
-	xor
-	loc 32768
+	loe three
+	loe one
+	xor EM_WSIZE
+	loc 2
 	cmu EM_WSIZE
 	zeq *1
 
@@ -22,33 +23,61 @@ four
     asp 4
 1
 
-	/* Xor triple-word-sized set */
+	/* Xor var with const */
 
-four_by_three
-	rom EM_WSIZE*3
-
-	loc 32769
-	loc 32770
-	loc 32772
+	loe three
 	loc 1
+	xor EM_WSIZE
 	loc 2
-	loc 4
-	loe four_by_three
-	xor
-	loc 32768
 	cmu EM_WSIZE
-	zne *2
-	loc 32768
-	cmu EM_WSIZE
-	zne *2
-	loc 32768
+	zeq *2
+
+    loc __LINE__
+    cal $fail
+    asp 4
+2
+
+	/* Xor const with var */
+
+	loc 3
+	loe one
+	xor EM_WSIZE
+	loc 2
 	cmu EM_WSIZE
 	zeq *3
-2
-	loc __LINE__
-	cal $fail
-	asp 4
+
+    loc __LINE__
+    cal $fail
+    asp 4
 3
+
+	/* Xor var with big const */
+
+	loe three
+	loc 1001
+	xor EM_WSIZE
+	loc 1002
+	cmu EM_WSIZE
+	zeq *4
+
+    loc __LINE__
+    cal $fail
+    asp 4
+4
+
+	/* Xor big const with var */
+
+	loc 1001
+	loe three
+	xor EM_WSIZE
+	loc 1002
+	cmu EM_WSIZE
+	zeq *5
+
+    loc __LINE__
+    cal $fail
+    asp 4
+5
 
     cal $finished
     end

--- a/tests/plat/core/xorv_e.e
+++ b/tests/plat/core/xorv_e.e
@@ -1,0 +1,54 @@
+#
+    mes 2, EM_WSIZE, EM_PSIZE
+
+    exp $_m_a_i_n
+    pro $_m_a_i_n, 0
+
+	/* Xor word-sized set */
+
+four
+	rom EM_WSIZE
+
+	loc 32769
+	loc 1
+	loe four		/* to defeat constant folding */
+	xor
+	loc 32768
+	cmu EM_WSIZE
+	zeq *1
+
+    loc __LINE__
+    cal $fail
+    asp 4
+1
+
+	/* Xor triple-word-sized set */
+
+four_by_three
+	rom EM_WSIZE*3
+
+	loc 32769
+	loc 32770
+	loc 32772
+	loc 1
+	loc 2
+	loc 4
+	loe four_by_three
+	xor
+	loc 32768
+	cmu EM_WSIZE
+	zne *2
+	loc 32768
+	cmu EM_WSIZE
+	zne *2
+	loc 32768
+	cmu EM_WSIZE
+	zeq *3
+2
+	loc __LINE__
+	cal $fail
+	asp 4
+3
+
+    cal $finished
+    end


### PR DESCRIPTION
Also, let's add tests.

Reduces Star Trek from 41858 bytes to 41650 bytes.