### PR TITLE
Bugfix of compilation on gcc 4.8

### DIFF
--- a/plat/cpm/emu/biosbdos.c
+++ b/plat/cpm/emu/biosbdos.c
@@ -114,7 +114,8 @@ static void bios_warmboot(void)
 	close(fd);
 
 	int offset = 1;
-	for (int word = 1; user_command_line[word]; word++)
+	int word;
+	for (word = 1; user_command_line[word]; word++)
 	{
 		if (word > 1)
 		{

--- a/plat/cpm/emu/biosbdos.c
+++ b/plat/cpm/emu/biosbdos.c
@@ -88,6 +88,8 @@ void bios_coldboot(void)
 
 static void bios_warmboot(void)
 {
+	int word;	
+	int offset = 1;
 	dma = 0x0080;
 
 	if (!user_command_line[0])
@@ -113,8 +115,6 @@ static void bios_warmboot(void)
 	read(fd, &ram[0x0100], 0xFE00);
 	close(fd);
 
-	int offset = 1;
-	int word;
 	for (word = 1; user_command_line[word]; word++)
 	{
 		if (word > 1)

--- a/plat/cpm/emu/emulator.c
+++ b/plat/cpm/emu/emulator.c
@@ -104,11 +104,12 @@ static void cmd_register(void)
 
 static void cmd_break(void)
 {
+	int i;
 	char* w1 = strtok(NULL, delimiters);
 	if (w1)
 	{
 		uint16_t breakpc = strtoul(w1, NULL, 16);
-		for (int i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
+		for (i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
 		{
 			if (breakpoints[i] == 0xffff)
 			{
@@ -120,7 +121,7 @@ static void cmd_break(void)
 	}
 	else
 	{
-		for (int i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
+		for (i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
 		{
 			if (breakpoints[i] != 0xffff)
 				printf("%04x\n", breakpoints[i]);
@@ -130,11 +131,12 @@ static void cmd_break(void)
 
 static void cmd_watch(void)
 {
+	int i;
 	char* w1 = strtok(NULL, delimiters);
 	if (w1)
 	{
 		uint16_t watchaddr = strtoul(w1, NULL, 16);
-		for (int i=0; i<sizeof(watchpoints)/sizeof(*watchpoints); i++)
+		for (i=0; i<sizeof(watchpoints)/sizeof(*watchpoints); i++)
 		{
 			struct watchpoint* w = &watchpoints[i];
 			if (!w->enabled)
@@ -149,7 +151,7 @@ static void cmd_watch(void)
 	}
 	else
 	{
-		for (int i=0; i<sizeof(watchpoints)/sizeof(*watchpoints); i++)
+		for (i=0; i<sizeof(watchpoints)/sizeof(*watchpoints); i++)
 		{
 			struct watchpoint* w = &watchpoints[i];
 			if (w->enabled)
@@ -160,11 +162,12 @@ static void cmd_watch(void)
 
 static void cmd_delete_breakpoint(void)
 {
+	int i;
 	char* w1 = strtok(NULL, delimiters);
 	if (w1)
 	{
 		uint16_t breakpc = strtoul(w1, NULL, 16);
-		for (int i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
+		for (i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
 		{
 			if (breakpoints[i] == breakpc)
 			{
@@ -178,11 +181,12 @@ static void cmd_delete_breakpoint(void)
 
 static void cmd_delete_watchpoint(void)
 {
+	int i;
 	char* w1 = strtok(NULL, delimiters);
 	if (w1)
 	{
 		uint16_t address = strtoul(w1, NULL, 16);
-		for (int i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
+		for (i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
 		{
 			struct watchpoint* w = &watchpoints[i];
 			if (w->enabled && (w->address == address))
@@ -197,6 +201,7 @@ static void cmd_delete_watchpoint(void)
 
 static void cmd_memory(void)
 {
+	int i;
 	char* w1 = strtok(NULL, delimiters);
 	char* w2 = strtok(NULL, delimiters);
 
@@ -215,7 +220,7 @@ static void cmd_memory(void)
 		while (p < endrounded)
 		{
 			printf("%04x : ", p);
-			for (int i = 0; i < 16; i++)
+			for (i = 0; i < 16; i++)
 			{
 				uint16_t pp = p + i;
 				if ((pp >= startaddr) && (pp < endaddr))
@@ -224,7 +229,7 @@ static void cmd_memory(void)
 					printf("   ");
 			}
 			printf(": ");
-			for (int i = 0; i < 16; i++)
+			for (i = 0; i < 16; i++)
 			{
 				uint16_t pp = p + i;
 				if ((pp >= startaddr) && (pp < endaddr))
@@ -359,7 +364,8 @@ static void sigusr1_cb(int number)
 
 void emulator_init(void)
 {
-	for (int i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
+	int i;
+	for (i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
 		breakpoints[i] = 0xffff;
 
 	singlestepping = flag_enter_debugger;
@@ -372,16 +378,17 @@ void emulator_init(void)
 
 void emulator_run(void)
 {
+	int i;
 	for (;;)
 	{
 		uint16_t pc = i8080_read_reg16(PC);
 		if (!singlestepping)
 		{
-			for (int i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
+			for (i=0; i<sizeof(breakpoints)/sizeof(*breakpoints); i++)
 				if (pc == breakpoints[i])
 					singlestepping = true;
 		}
-		for (int i=0; i<sizeof(watchpoints)/sizeof(*watchpoints); i++)
+		for (i=0; i<sizeof(watchpoints)/sizeof(*watchpoints); i++)
 		{
 			struct watchpoint* w = &watchpoints[i];
 			if (w->enabled && (ram[w->address] != w->value))

--- a/plat/cpm/emu/fileio.c
+++ b/plat/cpm/emu/fileio.c
@@ -37,11 +37,12 @@ static DIR* currentdir;
 
 void files_init(void)
 {
-	for (int i=0; i<NUM_DRIVES; i++)
+	int i;
+	for (i=0; i<NUM_DRIVES; i++)
 		drives[i] = -1;
 	file_set_drive(0, ".");
 
-	for (int i=0; i<NUM_FILES; i++)
+	for (i=0; i<NUM_FILES; i++)
 	{
 		struct file* f = &files[i];
 		if (i == 0)
@@ -113,17 +114,18 @@ static void bump(struct file* f)
 
 static void cpm_filename_to_unix(cpm_filename_t* cpmfilename, char* unixfilename)
 {
+	int i;
 	char* pin = cpmfilename->bytes;
 	char* pout = unixfilename;
 
-	for (int i=0; i<8; i++)
+	for (i=0; i<8; i++)
 	{
 		char c = *pin++;
 		if (c != ' ')
 			*pout++ = tolower(c);
 	}
 	*pout++ = '.';
-	for (int i=0; i<3; i++)
+	for (i=0; i<3; i++)
 	{
 		char c = *pin++;
 		if (c != ' ')
@@ -169,10 +171,11 @@ static bool unix_filename_to_cpm(const char* unixfilename, cpm_filename_t* cpmfi
 
 static bool match_filenames(cpm_filename_t* pattern, cpm_filename_t* filename)
 {
+	int i;
 	if (pattern->drive != filename->drive)
 		return false;
 
-	for (int i=0; i<sizeof(pattern->bytes); i++)
+	for (i=0; i<sizeof(pattern->bytes); i++)
 	{
 		char p = pattern->bytes[i];
 		if (p == '?')


### PR DESCRIPTION
Small fix to build using my linux machine, GCC 4.8 does not enable C99 extensions by default. Also permits to test my skills using github. 