### PR TITLE
i80: fix signed comparisons

### DIFF
--- a/mach/i80/libem/rst.s
+++ b/mach/i80/libem/rst.s
@@ -17,6 +17,11 @@
     shld 0x11
     lxi h, rst3
     shld 0x19
+
+    lhld rst4
+    shld 0x20
+    lhld rst4+2
+    shld 0x22
     ret
 
     ! de = [bc+const1] (remember bc is the frame pointer)
@@ -70,3 +75,8 @@ rst3:
     dad b
     ret
     
+    ! Adjust flags for signed comparison
+rst4:
+    rpo
+    xri 0x80
+    ret

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -13,6 +13,12 @@ EM_WSIZE = 2
 EM_PSIZE = 2
 EM_BSIZE = 4
 
+#ifdef USE_I80_RSTS
+   #define SIGN_ADJUST rst {const1, 4}
+#else
+   #define SIGN_ADJUST jpo {label, 1f} xri {const1, 0x80} 1:
+#endif
+
 SL=4
 
 PROPERTIES
@@ -103,7 +109,7 @@ INSTRUCTIONS
    jnz	label:ro			cost(3,10).
    jp	label:ro			cost(3,10).
 /* jpe	label:ro			cost(3,10).	*/
-/* jpo	label:ro			cost(3,10).	*/
+   jpo	label:ro			cost(3,10).
    jz	label:ro			cost(3,10).
    lda	label:ro 	kills a		cost(3,13).
    ldax	regind:ro 	kills a		cost(1, 7).
@@ -1860,6 +1866,7 @@ pat blt
          sui {const1, %1.num & 0xff}
          mov a, %2.1
          sbi {const1, %1.num >> 8}
+         SIGN_ADJUST
          jm {label, $1}
    with hl_or_de const2 STACK
       uses areg
@@ -1868,14 +1875,16 @@ pat blt
          sub %1.2
          mvi a, {const1, %2.num >> 8}
          sbb %1.1
+         SIGN_ADJUST
          jm {label, $1}
    with hl_or_de hl_or_de STACK
       uses areg
       gen
-         mov a,%2.2
+         mov a, %2.2
          sub %1.2
-         mov a,%2.1
+         mov a, %2.1
          sbb %1.1
+         SIGN_ADJUST
          jm {label,$1}
 
 pat bgt
@@ -1891,6 +1900,7 @@ pat bge
          sui {const1, %1.num & 0xff}
          mov a, %2.1
          sbi {const1, %1.num >> 8}
+         SIGN_ADJUST
          jp {label, $1}
    with hl_or_de const2 STACK
       uses areg
@@ -1899,6 +1909,7 @@ pat bge
          sub %1.2
          mvi a, {const1, %2.num >> 8}
          sbb %1.1
+         SIGN_ADJUST
          jp {label, $1}
    with hl_or_de hl_or_de STACK
       uses areg
@@ -1907,6 +1918,7 @@ pat bge
          sub %1.2
          mov a,%2.1
          sbb %1.1
+         SIGN_ADJUST
          jp {label,$1}
 
 pat ble

--- a/mach/i80/top/table
+++ b/mach/i80/top/table
@@ -1,5 +1,5 @@
 
-/* 68020 desciptor table for ACK target optimizer */
+/* 8080 desciptor table for ACK target optimizer */
 
 MAXOP 2;
 
@@ -14,5 +14,6 @@ xchg : inx h : xchg          -> inx d ;
 xchg : inx d : xchg          -> inx h ;
 
 cpi 0                        -> ora a ;
+call X : ret                 -> jmp X ;
 
 %%;

--- a/plat/cpm/emu/globals.h
+++ b/plat/cpm/emu/globals.h
@@ -1,6 +1,7 @@
 #ifndef GLOBALS_H
 #define GLOBALS_H
 
+#include <stdint.h>
 #include <stdbool.h>
 
 extern uint8_t ram[0x10000];

--- a/tests/plat/core/cmi_e.e
+++ b/tests/plat/core/cmi_e.e
@@ -1,0 +1,114 @@
+#
+    mes 2, EM_WSIZE, EM_PSIZE
+
+    exp $_m_a_i_n
+    pro $_m_a_i_n, 0
+
+mbig
+    #if EM_WSIZE == 2
+        rom 32768
+    #else
+        rom 2147483648
+    #endif
+mone
+    rom -1
+zero
+    rom 0
+one
+    rom 1
+big
+    #if EM_WSIZE == 2
+        rom 32767
+    #else
+        rom 2147483647
+    #endif
+
+	/* 0 < 1 */
+
+    loe zero
+    loe one
+    blt *1
+    cmi EM_WSIZE
+    zlt *1
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+1
+
+    /* 1 > 0 */
+
+    loe one
+    loe zero
+    cmi EM_WSIZE
+    zgt *2
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+2
+
+    /* 0 <= 0 */
+
+    loe zero
+    loe zero
+    cmi EM_WSIZE
+    zle *3
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+3
+
+    /* 0 >= 0 */
+
+    loe zero
+    loe zero
+    cmi EM_WSIZE
+    zge *4
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+4
+
+	/* INT_MIN < 1 */
+
+    loe mbig
+    loe one
+    cmi EM_WSIZE
+    zlt *5
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+5
+
+    /* 1 > INT_MIN */
+
+    loe one
+    loe mbig
+    cmi EM_WSIZE
+    zgt *6
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+6
+
+    /* INT_MIN < INT_MAX */
+
+    loe mbig
+    loe big
+    cmi EM_WSIZE
+    zlt *7
+    
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+7
+
+    cal $finished
+    end
+
+

--- a/tests/plat/core/cmu_e.e
+++ b/tests/plat/core/cmu_e.e
@@ -1,0 +1,111 @@
+#
+    mes 2, EM_WSIZE, EM_PSIZE
+
+    exp $_m_a_i_n
+    pro $_m_a_i_n, 0
+
+mbig
+    #if EM_WSIZE == 2
+        rom 32768
+    #else
+        rom 2147483648
+    #endif
+mone
+    rom -1
+zero
+    rom 0
+one
+    rom 1
+big
+    #if EM_WSIZE == 2
+        rom 32767
+    #else
+        rom 2147483647
+    #endif
+
+	/* 0 < 1 */
+
+    loe zero
+    loe one
+    cmu EM_WSIZE
+    zlt *1
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+1
+
+    /* 1 > 0 */
+
+    loe one
+    loe zero
+    cmu EM_WSIZE
+    zgt *2
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+2
+
+    /* 0 <= 0 */
+
+    loe zero
+    loe zero
+    cmu EM_WSIZE
+    zle *3
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+3
+
+    /* 0 >= 0 */
+
+    loe zero
+    loe zero
+    cmu EM_WSIZE
+    zge *4
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+4
+
+	/* INT_MIN > 1 */
+
+    loe mbig
+    loe one
+    cmu EM_WSIZE
+    zgt *5
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+5
+
+    /* 1 < INT_MIN */
+
+    loe one
+    loe mbig
+    cmu EM_WSIZE
+    zlt *6
+
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+6
+
+    /* INT_MIN > INT_MAX */
+
+    loe mbig
+    loe big
+    cmu EM_WSIZE
+    zgt *7
+    
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+7
+
+    cal $finished
+    end


### PR DESCRIPTION
Fix an issue where the code generator was producing incorrect code for signed comparisons. (Spending another rst on the fixup code to reduce code size.)

Note that the emulator is buggy and causes all the tests to fail. Running in cowgol's z80ex-based emulator makes them pass.