### PR TITLE
i80: fix bad code in comparisons

### DIFF
--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -2048,14 +2048,15 @@ gen xra a
 
 #ifdef USE_I80_RSTS
    pat lol zeq sfit($1, 8)
-      uses hlreg, areg
-      gen
-         rst {const1, 3}
-         data1 {const1, $1}
-         mov a, {m}
-         inx hl
-         ora {m}
-         jz {label, $2}
+      with STACK
+         uses hlreg, areg
+         gen
+            rst {const1, 3}
+            data1 {const1, $1}
+            mov a, {m}
+            inx hl
+            ora {m}
+            jz {label, $2}
 #endif
 
 pat lol zeq
@@ -2070,25 +2071,26 @@ pat lol zeq
 
 #ifdef USE_I80_RSTS
    pat lol zne sfit($1, 8)
-      uses hlreg, areg
-      gen
-         rst {const1, 3}
-         data1 {const1, $1}
-         mov a, {m}
-         inx hl
-         ora {m}
-         jnz {label, $2}
+      with STACK
+         uses hlreg, areg
+         gen
+            rst {const1, 3}
+            data1 {const1, $1}
+            mov a, {m}
+            inx hl
+            ora {m}
+            jnz {label, $2}
 #endif
 
 pat lol zne
    with STACK
-   uses hlreg={const2,$1}, areg
-   gen
-      dad lb
-      mov a,{m}
-      inx hl
-      ora {m}
-      jnz {label,$2}
+      uses hlreg={const2,$1}, areg
+      gen
+         dad lb
+         mov a,{m}
+         inx hl
+         ora {m}
+         jnz {label,$2}
 
 pat ior zeq $1==2
 with hl_or_de hl_or_de STACK

--- a/tests/plat/bugs/bug-157-i80-varargs_c.c
+++ b/tests/plat/bugs/bug-157-i80-varargs_c.c
@@ -56,7 +56,7 @@ void demo2(int lval, va_list ap)
     ASSERT(strcmp(ptmp, "35") == 0);
 }
 
-void doit1(char *x, ...)
+void doit1a(char *x, ...)
 {
     va_list ptr;
     va_start(ptr, x);
@@ -64,7 +64,15 @@ void doit1(char *x, ...)
     va_end(ptr);
 }
 
-void doit2(char *x, ...)
+void doit1b(char *x, ...)
+{
+    va_list ptr;
+    va_start(ptr, x);
+    demo(1,ptr);
+    va_end(ptr);
+}
+
+void doit2a(char *x, ...)
 {
     va_list ptr;
     va_start(ptr, x);
@@ -72,10 +80,20 @@ void doit2(char *x, ...)
     va_end(ptr);
 }
 
+void doit2b(char *x, ...)
+{
+    va_list ptr;
+    va_start(ptr, x);
+    demo2(1,ptr);
+    va_end(ptr);
+}
+
 int main(int argc, char *argv[])
 {
-    doit1("", 35);
-    doit2("", 35);
+    doit1a("", 35);
+    doit1b("", 35L);
+    doit2a("", 35);
+    doit2b("", 35L);
     finished();
     return 0;
 }

--- a/tests/plat/bugs/bug-157-i80-varargs_c.c
+++ b/tests/plat/bugs/bug-157-i80-varargs_c.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include "test.h"
+
+static char buf[34];
+
+char * __ultostr(unsigned long val, int radix)
+{
+   register char *p;
+   register int c;
+
+   if( radix > 36 || radix < 2 ) return 0;
+
+   p = buf+sizeof(buf);
+   *--p = '\0';
+
+   do
+   {
+      c = val%radix;
+      val/=radix;
+      if( c > 9 ) *--p = 'a'-10+c; else *--p = '0'+c;
+   }
+   while(val);
+   return p;
+}
+
+char * __ltostr(long val, int radix)
+{
+   char *p;
+   int flg = 0;
+   if( val < 0 ) { flg++; val= -val; }
+   p = __ultostr(val, radix);
+   if(p && flg) *--p = '-';
+   return p;
+}
+
+void demo(int lval, va_list ap)
+{
+    char *ptmp = __ltostr((long) ((lval) ?
+			    va_arg(ap, long) :
+			    va_arg(ap, int)), 10);
+    ASSERT(strcmp(ptmp, "35") == 0);
+}
+
+void demo2(int lval, va_list ap)
+{
+    long l;
+    char *ptmp;
+    
+    l = (lval) ?va_arg(ap, long) :
+		 va_arg(ap, int);
+    ptmp = __ltostr(l, 10);
+    ASSERT(strcmp(ptmp, "35") == 0);
+}
+
+void doit1(char *x, ...)
+{
+    va_list ptr;
+    va_start(ptr, x);
+    demo(0,ptr);
+    va_end(ptr);
+}
+
+void doit2(char *x, ...)
+{
+    va_list ptr;
+    va_start(ptr, x);
+    demo2(0,ptr);
+    va_end(ptr);
+}
+
+int main(int argc, char *argv[])
+{
+    doit1("", 35);
+    doit2("", 35);
+    finished();
+    return 0;
+}


### PR DESCRIPTION
Fix bad code generation due to not correctly flushing the stack before branches.

Fixes: #157 