### PR TITLE
i80, powerpc, mips: fix issue with logical operations and signed small constants

### DIFF
--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -46,7 +46,8 @@ TOKENS
 
 const1			= { INT num; } 1 num.
 const2			= { INT num; } 2 num.
-smallconst2    = { INT num; } 2 num.
+smallpconst2   = { INT num; } 2 num. /* Byte-sized positive constant */
+smallnconst2   = { INT num; } 2 num. /* Byte-sized negative constant */
 label			= { ADDR off; } 2 off.
 m			= { } 2 cost(0,3) "m".
 
@@ -55,7 +56,7 @@ SETS
 reg1			= reg + lbreg + m.
 b_d_h_sp		= regpair + stackpointer.
 b_d_h_psw		= regpair + psword.
-immediate		= smallconst2 + const2 + label.
+immediate		= smallpconst2 + smallnconst2 + const2 + label.
 src1			= reg.
 src2			= hl_or_de + const2 + label.
 src1or2			= src1 + src2.
@@ -226,7 +227,10 @@ gen move %1,%a.2
 
 from hl_or_de				yields %1.2
 
-from smallconst2
+from smallpconst2
+   yields {const2, %1.num}
+
+from smallnconst2
    yields {const2, %1.num}
 
 from const2
@@ -243,8 +247,11 @@ PATTERNS
 /* Group 1: Load instructions                */
 /*********************************************/
 
-pat loc sfit($1, 8)
-   yields {smallconst2, $1}
+pat loc ufit($1, 8)
+   yields {smallpconst2, $1}
+
+pat loc sfit($1, 8) && ($1<0)
+   yields {smallnconst2, $1}
 
 pat loc
    yields {const2, $1}
@@ -651,8 +658,8 @@ pat sbi $1==2
       yields %2 {const2, 0-%1.num}
       leaving
          adi 2
-   with smallconst2 hl_or_de
-      yields %2 {smallconst2, 0-%1.num}
+   with smallnconst2 hl_or_de
+      yields %2 {smallpconst2, 0-%1.num}
       leaving
          adi 2
    with hl_or_de const2
@@ -1176,14 +1183,27 @@ leaving loc $1 loc $2 cal ".cfu" asp 4+$1 lfr 4
 /*****************************************/
 
 pat and $1==2
-   with hl_or_de smallconst2
+   with hl_or_de smallpconst2
+      uses areg
+      gen
+         mov a, %1.2
+         ani {const1, %2.num & 0xff}
+      yields a
+   with smallpconst2 hl_or_de
+      yields %1 %2
+      leaving
+         and 2
+   with hl_or_de smallnconst2
       uses areg
       gen
          mov a, %1.2
          ani {const1, %2.num & 0xff}
          mov %1.2, a
-         mvi %1.1, {const1, 0}
       yields %1
+   with smallnconst2 hl_or_de
+      yields %1 %2
+      leaving
+         and 2
    with hl_or_de const2
       uses areg
       gen
@@ -1195,23 +1215,9 @@ pat and $1==2
          mov %1.1, a
       yields %1
    with const2 hl_or_de
-      uses areg
-      gen
-         mov a, %2.2
-         ani {const1, %1.num & 0xff}
-         mov %2.2, a
-         mov a, %2.1
-         ani {const1, %1.num >> 8}
-         mov %2.1, a
-      yields %2
-   with smallconst2 hl_or_de
-      uses areg
-      gen
-         mov a, %2.2
-         ani {const1, %1.num & 0xff}
-         mov %2.2, a
-         mvi %2.1, {const1, 0}
-      yields %2
+      yields %1 %2
+      leaving
+         and 2
    with hl_or_de hl_or_de
       uses areg
       gen
@@ -1246,13 +1252,29 @@ pat and !defined($1)
          Call {label,".and"}
 
 pat ior $1==2
-   with hl_or_de smallconst2
+   with hl_or_de smallpconst2
       uses areg
       gen
          mov a, %1.2
          ori {const1, %2.num & 0xff}
          mov %1.2, a
       yields %1
+   with smallpconst2 hl_or_de
+      yields %1 %2
+      leaving
+         ior 2
+   with hl_or_de smallnconst2
+      uses areg
+      gen
+         mov a, %1.2
+         ori {const1, %2.num & 0xff}
+         mov %1.2, a
+         move {const1, 0xff}, %1.1
+      yields %1
+   with smallnconst2 hl_or_de
+      yields %1 %2
+      leaving
+         ior 2
    with hl_or_de const2
       uses areg
       gen
@@ -1264,22 +1286,9 @@ pat ior $1==2
          mov %1.1, a
       yields %1
    with const2 hl_or_de
-      uses areg
-      gen
-         mov a, %2.2
-         ori {const1, %1.num & 0xff}
-         mov %2.2, a
-         mov a, %2.1
-         ori {const1, %1.num >> 8}
-         mov %2.1, a
-      yields %2
-   with smallconst2 hl_or_de
-      uses areg
-      gen
-         mov a, %2.2
-         ori {const1, %1.num & 0xff}
-         mov %2.2, a
-      yields %2
+      yields %1 %2
+      leaving
+         ior 2
    with hl_or_de hl_or_de
       uses areg
       gen
@@ -1312,13 +1321,17 @@ kills ALL
 gen Call {label,".ior"}
 
 pat xor $1==2
-   with hl_or_de smallconst2
+   with hl_or_de smallpconst2
       uses areg
       gen
          mov a, %1.2
          xri {const1, %2.num & 0xff}
          mov %1.2, a
       yields %1
+   with smallpconst2 hl_or_de
+      yields %1 %2
+      leaving
+         xor 2
    with hl_or_de const2
       uses areg
       gen
@@ -1330,22 +1343,9 @@ pat xor $1==2
          mov %1.1, a
       yields %1
    with const2 hl_or_de
-      uses areg
-      gen
-         mov a, %2.2
-         xri {const1, %1.num & 0xff}
-         mov %2.2, a
-         mov a, %2.1
-         xri {const1, %1.num >> 8}
-         mov %2.1, a
-      yields %2
-   with smallconst2 hl_or_de
-      uses areg
-      gen
-         mov a, %2.2
-         xri {const1, %1.num & 0xff}
-         mov %2.2, a
-      yields %2
+      yields %1 %2
+      leaving
+         xor 2
    with hl_or_de hl_or_de
       uses areg
       gen

--- a/mach/mips/mcg/table
+++ b/mach/mips/mcg/table
@@ -799,26 +799,26 @@ PATTERNS
             cost 4;                                        \
 
 	/* reg + const */
-    #define ALUC(name, instr) \
+    #define ALUC(name, instr, predicate) \
         out:(int)reg = name(left:intregorzero, right:CONST.I)  \
-            when signed_constant(%right, 16)               \
+            when predicate(%right, 16)                     \
             emit instr " %out, %left, $right"              \
             cost 4;                                        \
 
 	/* const + reg */
-    #define ALUC_reversed(name, instr) \
+    #define ALUC_reversed(name, instr, predicate) \
         out:(int)reg = name(left:CONST.I, right:intregorzero)  \
-            when signed_constant(%left, 16)                \
+            when predicate(%left, 16)                      \
             emit instr " %out, %right, $left"              \
             cost 4;                                        \
 
 	/* reg + const AND const + reg */
-    #define ALUCC(name, instr) \
-        ALUC(name, instr) \
-        ALUC_reversed(name, instr)
+    #define ALUCC(name, instr, predicate)                  \
+        ALUC(name, instr, predicate)                       \
+        ALUC_reversed(name, instr, predicate)
 
     ALUR(ADD.I, "addu")
-    ALUCC(ADD.I, "addiu")
+    ALUCC(ADD.I, "addiu", signed_constant)
 
 	out:(int)reg = SUB.I(left:intregorzero, right:intregorzero)
 		emit "subu %out, %left, %right"
@@ -851,14 +851,14 @@ PATTERNS
     ALUR(MUL.I, "mul")
 
     ALUR(ASL.I, "sllv")
-    ALUC(ASL.I, "sll")
+    ALUC(ASL.I, "sll", signed_constant)
     ALUR(ASR.I, "srav")
-    ALUC(ASR.I, "sra")
+    ALUC(ASR.I, "sra", signed_constant)
 
     ALUR(LSL.I, "sllv")
-    ALUC(LSL.I, "sll")
+    ALUC(LSL.I, "sll", signed_constant)
     ALUR(LSR.I, "srlv")
-    ALUC(LSR.I, "srl")
+    ALUC(LSR.I, "srl", signed_constant)
 
     out:(int)reg = NEG.I(left:intregorzero)
         emit "subu %out, zero, %left"
@@ -869,13 +869,13 @@ PATTERNS
         cost 4;
 
     ALUR(AND.I, "and")
-    ALUCC(AND.I, "andi")
+    ALUCC(AND.I, "andi", signed_constant)
 
     ALUR(OR.I, "or")
-    ALUCC(OR.I, "ori")
+    ALUCC(OR.I, "ori", unsigned_constant)
 
     ALUR(EOR.I, "xor")
-    ALUCC(EOR.I, "xori")
+    ALUCC(EOR.I, "xori", unsigned_constant)
 
 	out:(int)reg = value:LABEL.I
 		emit "lui %out, hi16[$value]"

--- a/mach/powerpc/ncg/table
+++ b/mach/powerpc/ncg/table
@@ -1574,10 +1574,10 @@ PATTERNS
 			yields {OR_RIS, %2, hi(%1.val)}
 		with REG CONST_STACK-UCONST2-CONST_HI_ZR
 			uses reusing %1, REG={OR_RIS, %1, hi(%2.val)}
-			yields {OR_RC, %1, lo(%2.val)}
+			yields {OR_RC, %a, lo(%2.val)}
 		with CONST_STACK-UCONST2-CONST_HI_ZR REG
 			uses reusing %2, REG={OR_RIS, %2, hi(%1.val)}
-			yields {OR_RC, %2, lo(%1.val)}
+			yields {OR_RC, %a, lo(%1.val)}
 
 	pat ior defined($1)                /* OR set */
 		leaving
@@ -1602,10 +1602,10 @@ PATTERNS
 			yields {XOR_RIS, %2, hi(%1.val)}
 		with REG CONST_STACK-UCONST2-CONST_HI_ZR
 			uses reusing %1, REG={XOR_RIS, %1, hi(%2.val)}
-			yields {XOR_RC, %1, lo(%2.val)}
+			yields {XOR_RC, %a, lo(%2.val)}
 		with CONST_STACK-UCONST2-CONST_HI_ZR REG
 			uses reusing %2, REG={XOR_RIS, %2, hi(%1.val)}
-			yields {XOR_RC, %2, lo(%1.val)}
+			yields {XOR_RC, %a, lo(%1.val)}
 
 	pat xor defined($1)                /* XOR set */
 		leaving

--- a/tests/plat/core/and_e.e
+++ b/tests/plat/core/and_e.e
@@ -8,6 +8,8 @@ three
 	rom 3
 one
 	rom 1
+mone
+	rom -1
 big
 	rom 256
 
@@ -80,6 +82,34 @@ big
     cal $fail
     asp 4
 5
+
+	/* And big const with negative var */
+
+	loc 257
+	loe mone
+	and EM_WSIZE
+	loc 257
+	cmu EM_WSIZE
+	zeq *6
+
+    loc __LINE__
+    cal $fail
+    asp 4
+6
+
+	/* And big var with negative const */
+
+	loe big
+	loc -1
+	and EM_WSIZE
+	loe big
+	cmu EM_WSIZE
+	zeq *7
+
+    loc __LINE__
+    cal $fail
+    asp 4
+7
 
     cal $finished
     end

--- a/tests/plat/core/ior_e.e
+++ b/tests/plat/core/ior_e.e
@@ -8,6 +8,10 @@ zero
 	rom 0
 one
 	rom 1
+mone
+	rom -1
+big
+	rom 257
 
 	/* Or var with var */
 
@@ -78,6 +82,34 @@ one
     cal $fail
     asp 4
 5
+
+	/* Or big const with negative var */
+
+	loc 1000
+	loe mone
+	ior EM_WSIZE
+	loc -1
+	cmu EM_WSIZE
+	zeq *6
+
+    loc __LINE__
+    cal $fail
+    asp 4
+6
+
+	/* Or big var with negative const */
+
+	loe big
+	loc -1
+	ior EM_WSIZE
+	loe big
+	cmu EM_WSIZE
+	zeq *7
+
+    loc __LINE__
+    cal $fail
+    asp 4
+7
 
     cal $finished
     end

--- a/tests/plat/core/ior_e.e
+++ b/tests/plat/core/ior_e.e
@@ -11,7 +11,7 @@ one
 mone
 	rom -1
 big
-	rom 257
+	rom 258
 
 	/* Or var with var */
 
@@ -27,12 +27,12 @@ big
     asp 4
 1
 
-	/* Or var with const */
+	/* Or big var with const */
 
-	loe zero
+	loe big
 	loc 1
 	ior EM_WSIZE
-	loc 1
+	loc 259
 	cmu EM_WSIZE
 	zeq *2
 
@@ -102,7 +102,7 @@ big
 	loe big
 	loc -1
 	ior EM_WSIZE
-	loe big
+	loc -1
 	cmu EM_WSIZE
 	zeq *7
 

--- a/tests/plat/core/xor_e.e
+++ b/tests/plat/core/xor_e.e
@@ -8,6 +8,10 @@ three
 	rom 3
 one
 	rom 1
+mone
+	rom -1
+big
+	rom 1001
 
 	/* Xor var with var */
 
@@ -78,6 +82,35 @@ one
     cal $fail
     asp 4
 5
+
+	/* Xor big const with negative var */
+
+	loc 1001
+	loe mone
+	xor EM_WSIZE
+	loc -1002
+	cmu EM_WSIZE
+	zeq *6
+
+    loc __LINE__
+    cal $fail
+    asp 4
+6
+
+	/* Xor big var with negative const */
+
+	loe big
+	loc -1
+	xor EM_WSIZE
+	loc -1002
+	cmu EM_WSIZE
+	zeq *7
+
+    loc __LINE__
+    cal $fail
+    asp 4
+7
+
 
     cal $finished
     end


### PR DESCRIPTION
Turns out that sign extending small constants is a little trickier than it looks, and three different architectures were doing it incorrectly. This adds tests for this and fixes it.

Fixes: #159 