### PR TITLE
i80: fix pathological behaviour in asp

### DIFF
--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -53,6 +53,7 @@ smallnconst2   = { INT num; } 2 num. /* Byte-sized negative constant */
 label			= { ADDR off; } 2 off.
 plabel      = { ADDR off; INT param; } 2 off param.
 m			= { } 2 cost(0,3) "m".
+comment        = { ADDR str; } 2 "! " str.
 
 SETS
 
@@ -118,7 +119,7 @@ INSTRUCTIONS
    mov  m:wo,reg1:ro			cost(1, 4).
    mov  reg1:wo,m:ro			cost(1, 4).
    mvi	reg1:wo,const1:ro		cost(2, 7).
-/* nop					cost(1, 3).	*/
+   nop comment:ro					cost(1, 3).
    ora	reg1:ro 	kills a:cc	cost(1, 4).
    ori	const1:ro 	kills a:cc	cost(2, 7).
 /* out	const1:ro			cost(2,10).	*/
@@ -2161,12 +2162,22 @@ gen 1:
 /* Group 15: Miscellaneous		  */
 /******************************************/
 
-pat asp ($1<=0-12) || ($1>=12)
+pat asp $1==0 /* do nothing */
+
+pat asp ($1==2)
+   with regpair
    with STACK
-      uses hlreg={const2,$1}
+      uses hlreg
       gen
-         dad sp
-         sphl.
+         pop hl
+
+pat asp ($1==4)
+   with regpair regpair
+   with STACK
+      uses hlreg
+      gen
+         pop hl
+         pop hl
 
 pat asp ($1<0) && ($1>0-12)
    with STACK
@@ -2175,15 +2186,20 @@ pat asp ($1<0) && ($1>0-12)
       leaving
          asp $1+2
 
-pat asp $1==0 /* do nothing */
-
-pat asp ($1>0) && ($1<12)
+pat asp ($1>4) && ($1<12)
    with STACK
       uses hlreg
       gen
          pop hl
       leaving
          asp $1-2
+
+pat asp
+   with STACK
+      uses hlreg={const2,$1}
+      gen
+         dad sp
+         sphl.
 
 pat ass $1==2
 with hlreg STACK


### PR DESCRIPTION
 Turns out that every time the compiler tried to do a stack retraction with asp, it would flush registers onto the stack. This stops it doing this. Star Trek goes from 40779 to 40452 bytes.