### PR TITLE
i80: fix bad code in inl using faddrn

### DIFF
--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -954,7 +954,7 @@ pat inc
          inx %1
       yields %1
 
-pat inl ($1>0) && ($1<STACKHELPERS)
+pat inl ($1>0) && ($1<=STACKHELPERS)
    uses hlreg
       gen
          Call {plabel, ".faddr", $1}
@@ -964,10 +964,10 @@ pat inl ($1>0) && ($1<STACKHELPERS)
          inr {m}
          1:
 
-pat inl ($1<0) && ($1<0-STACKHELPERS)
+pat inl ($1<0) && ($1>=0-STACKHELPERS)
    uses hlreg
       gen
-         Call {plabel, ".faddrn", $1}
+         Call {plabel, ".faddrn", 0-$1}
          inr {m}
          jnz {label,1f}
          inx hl

--- a/tests/plat/bugs/bug-164-faddrn_c.c
+++ b/tests/plat/bugs/bug-164-faddrn_c.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include "test.h"
+
+int doit(void)
+{
+  char buf[128];
+  int i;
+  i++;
+}
+
+int main(int argc, char *argv[])
+{
+    doit();
+    finished();
+    return 0;
+}


### PR DESCRIPTION
We weren't generating the helper tool invocation correctly in the pattern for inl, causing link failures on certain stack shapes.

Fixes: #164 