### PR TITLE
i80: grabbag of optimisations

### DIFF
--- a/mach/i80/libem/cmps_mag.s
+++ b/mach/i80/libem/cmps_mag.s
@@ -1,0 +1,18 @@
+.sect .text
+.sect .rom
+.sect .data
+.sect .bss
+.sect .text
+
+! Does a tristate signed comparison of hl <> de.
+! Returns m flag if hl < de.
+! Returns p flag if hl >= de.
+! This doesn't set z coherently.
+
+.define .cmps_mag
+.cmps_mag:
+    mov a, d
+    xra h
+    jp .cmpu_mag ! signs are the same, so an unsigned comparison will do
+    xra h        ! set A=H and set the sign flag
+    ret

--- a/mach/i80/libem/cmps_mag.s
+++ b/mach/i80/libem/cmps_mag.s
@@ -15,4 +15,5 @@
     xra h
     jp .cmpu_mag ! signs are the same, so an unsigned comparison will do
     xra h        ! set A=H and set the sign flag
+    ral          ! move sign flag into carry
     ret

--- a/mach/i80/libem/cmpu_mag.s
+++ b/mach/i80/libem/cmpu_mag.s
@@ -1,0 +1,19 @@
+.sect .text
+.sect .rom
+.sect .data
+.sect .bss
+.sect .text
+
+! Does a tristate unsigned comparison of hl <> de.
+! Returns m flag if hl < de.
+! Returns p flag if hl >= de.
+! This doesn't set z coherently.
+
+.define .cmpu_mag
+.cmpu_mag:
+    mov a, e
+    sub l
+    mov a, d
+    sbb h
+    rar
+    ret

--- a/mach/i80/libem/cmpu_mag.s
+++ b/mach/i80/libem/cmpu_mag.s
@@ -15,5 +15,4 @@
     sub l
     mov a, d
     sbb h
-    rar
     ret

--- a/mach/i80/libem/rst.s
+++ b/mach/i80/libem/rst.s
@@ -11,6 +11,10 @@
 !     41 call .floadn4
 !     34 call .fload4
 !     28 call .fstoren2
+!
+! Also:
+!     48 call .cmps_mag
+!     25 call .cmpu_mag
 
 .define .rst_init
 .rst_init:
@@ -18,13 +22,14 @@
     lxi d, 0x0008
     call copy
     lxi h, .floadn4
-    lxi d, 0x0010
     call copy
     lxi h, .fload4
-    lxi d, 0x0018
     call copy
     lxi h, .fstoren2
-    lxi d, 0x0020
+    call copy
+    lxi h, .cmps_mag
+    call copy
+    lxi h, .cmpu_mag
     jmp copy
 
 ! Copies eight bytes from HL to DE.

--- a/mach/i80/libem/rst.s
+++ b/mach/i80/libem/rst.s
@@ -14,7 +14,6 @@
 !
 ! Also:
 !     48 call .cmps_mag
-!     25 call .cmpu_mag
 
 .define .rst_init
 .rst_init:
@@ -28,8 +27,6 @@
     lxi h, .fstoren2
     call copy
     lxi h, .cmps_mag
-    call copy
-    lxi h, .cmpu_mag
     jmp copy
 
 ! Copies eight bytes from HL to DE.
@@ -39,7 +36,7 @@ copy:
     mov a, m
     stax d
     inx h
-    inx d
+    inr e
     dcr c
     jnz .1
     ret

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -1878,7 +1878,11 @@ pat blt
    with hlreg dereg STACK
       uses areg
       gen
-         Call {label, ".cmps_mag"}
+         #ifdef USE_I80_RSTS
+            rst {const1, 5}
+         #else
+            Call {label, ".cmps_mag"}
+         #endif
          jm {label, $1}
 
 pat bgt
@@ -1890,7 +1894,11 @@ pat bge
    with hlreg dereg STACK
       uses areg
       gen
-         Call {label, ".cmpu_mag"}
+         #ifdef USE_I80_RSTS
+            rst {const1, 5}
+         #else
+            Call {label, ".cmps_mag"}
+         #endif
          jp {label, $1}
 
 pat ble
@@ -1949,62 +1957,68 @@ pat bne
          jnz {label,$1}
 
 pat zlt
-with STACK
-gen pop psw
-    ora a
-    jm {label,$1}
-with hl_or_de STACK
-gen mov a,%1.1
-    ora a
-    jm {label,$1}
+   with STACK
+      gen
+         pop psw
+         ora a
+         jm {label,$1}
+   with regpair STACK
+      gen
+         mov a,%1.1
+         ora a
+         jm {label,$1}
 
 pat zle
-with hl_or_de STACK
-uses areg
-gen xra a
-    add %1.1
-    jm {label,$1}
-    jnz {label,1f}
-    xra a
-    add %1.2
-    jz {label,$1}
-    1:
+   with regpair STACK
+      uses areg
+      gen
+         mov a, %1.1
+         ora a
+         jm {label, $1}
+         jnz {label, 1f}
+         ora %1.2
+         jz {label, $1}
+         1:
 
 pat zeq
-with hl_or_de STACK
-uses areg
-gen mov a,%1.1
-    ora %1.2
-    jz {label,$1}
+   with regpair STACK
+      uses areg
+      gen
+         mov a,%1.1
+         ora %1.2
+         jz {label,$1}
 
 pat zne
-with hl_or_de STACK
-uses areg
-gen mov a,%1.1
-    ora %1.2
-    jnz {label,$1}
+   with regpair STACK
+      uses areg
+      gen
+         mov a,%1.1
+         ora %1.2
+         jnz {label,$1}
 
 pat zge
-with STACK
-gen pop psw
-    ral.
-    jnc {label,$1}
-with hl_or_de STACK
-gen mov a,%1.1
-    ora a
-    jp {label,$1}
+   with STACK
+      gen
+         pop psw
+         ral.
+         jnc {label,$1}
+   with regpair STACK
+      gen
+         mov a,%1.1
+         ora a
+         jp {label,$1}
 
 pat zgt
-with hl_or_de STACK
-uses areg
-gen xra a
-    add %1.1
-    jm {label,1f}
-    jnz {label,$1}
-    xra a
-    add %1.2
-    jnz {label,$1}
-    1:
+   with regpair STACK
+      uses areg
+      gen
+         mov a, %1.1
+         ora a
+         jm {label, 1f}
+         jnz {label, $1}
+         ora %1.2
+         jnz {label, $1}
+         1:
 
 pat lol zeq
    with STACK
@@ -2027,22 +2041,24 @@ pat lol zne
          jnz {label,$2}
 
 pat ior zeq $1==2
-with hl_or_de hl_or_de STACK
-uses areg
-gen mov a,%1.1
-    ora %1.2
-    ora %2.1
-    ora %2.2
-    jz {label,$2}
+   with regpair regpair STACK
+      uses areg
+      gen
+         mov a,%1.1
+         ora %1.2
+         ora %2.1
+         ora %2.2
+         jz {label,$2}
 
 pat ior zne $1==2
-with hl_or_de hl_or_de STACK
-uses areg
-gen mov a,%1.1
-    ora %1.2
-    ora %2.1
-    ora %2.2
-    jnz {label,$2}
+   with regpair regpair STACK
+      uses areg
+      gen
+         mov a,%1.1
+         ora %1.2
+         ora %2.1
+         ora %2.2
+         jnz {label,$2}
 
 /*********************************************/
 /* Group 14: Procedure call instructions     */

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -157,94 +157,149 @@ INSTRUCTIONS
 
 MOVES
 
-from reg to reg
-gen mov %2,%1
+   from reg to reg
+      gen
+         mov %2,%1
 
-from const1 %num==0 to areg
-gen xra a
+   from const1 %num==0 to areg
+      gen
+         xra a
 
-from const1 to reg
-gen mvi %2,%1
+   from const1 to reg
+      gen
+         mvi %2,%1
 
-from immediate to b_d_h_sp
-gen lxi %2,%1
+   from immediate to b_d_h_sp
+      gen
+         lxi %2,%1
 
-from reg to regpair
-gen mov %2.2,%1
-    mvi %2.1,{const1,0}
+#if 0
+   from const1 to reg
+      gen
+         mvi %2, %1
+         
+   from const1 to regpair
+      gen
+         mvi %2.2, %1
+         mvi %2.1, {const1, 0}
+#endif
 
-from regpair to regpair
-gen mov %2.1,%1.1
-    mov %2.2,%1.2
+   from reg to regpair
+      gen
+         mov %2.2, %1
+         mvi %2.1, {const1,0}
+
+   from regpair to regpair
+      gen
+         mov %2.1, %1.1
+         mov %2.2, %1.2
 
 TESTS
 
-to test areg		/* dummy test, never used */
-gen ora a
+   to test areg		/* dummy test, never used */
+      gen
+         ora a
 
 STACKINGRULES
 
-from regpair to STACK
-gen push %1
+   from regpair to STACK
+      gen
+         push %1
 
-from immediate + reg to STACK
-uses hl_or_de
-gen move %1,%a
-    push %a
+   from immediate + reg to STACK
+      uses hl_or_de
+      gen
+         move %1, %a
+         push %a
 
-from immediate + reg to STACK
-gen push hl
-    move %1,hl
-    xthl.
+   from immediate + reg to STACK
+      gen
+         push hl
+         move %1, hl
+         xthl.
 
 COERCIONS
 
-from STACK
-uses regpair
-gen pop %a				yields %a
+   from STACK
+      uses regpair
+      gen
+         pop %a
+      yields %a
 
-from STACK
-uses hl_or_de
-gen pop %a				yields %a.2
+   from STACK
+      uses hl_or_de
+      gen
+         pop %a
+      yields %a.2
 
-from STACK
-uses areg
-gen dcx sp
-    pop psw
-    inx sp				yields a
+   from STACK
+      uses areg
+      gen
+         dcx sp
+         pop psw
+         inx sp
+      yields %a
 
-from immediate
-uses regpair
-gen move %1,%a				yields %a
+   from immediate
+      uses regpair=%1
+      yields %a
 
-from hl_or_de
-uses hl_or_de
-gen xchg.				yields %a
+   from hl_or_de
+      uses hl_or_de
+      gen
+         xchg.
+      yields %a
 
-from regpair
-uses regpair
-gen move %1,%a				yields %a
+   from regpair
+      uses regpair=%1
+      yields %a
 
-from reg
-uses reusing %1, hl_or_de
-gen move %1,%a.2
-    move {const1,0},%a.1		yields %a
+   from reg
+      uses reusing %1, hl_or_de
+      gen
+         move %1,%a.2
+         move {const1,0},%a.1
+      yields %a
 
-from hl_or_de				yields %1.2
+   from hl_or_de				yields %1.2
 
-from smallpconst2
-   yields {const2, %1.num}
+   from smallpconst2
+      yields {const2, %1.num}
 
-from smallnconst2
-   yields {const2, %1.num}
+   from smallnconst2
+      yields {const2, %1.num}
 
-from const2
-uses hl_or_de
-gen move %1,%a				yields %a.2
+   from const2
+      uses hl_or_de=%1
+      yields %a
 
-from hl_or_de
-uses areg
-gen move %1.2,a				yields a
+   from smallpconst2
+      uses reg={const1, %1.num & 0xff}
+      yields %a
+
+   from smallnconst2
+      uses reg={const1, %1.num & 0xff}
+      yields %a
+
+   from smallpconst2 %1.num == 1
+      uses reg={const1, 0}
+      gen
+         inr %a
+      yields %a
+
+   from smallnconst2 %1.num == 0-1
+      uses reg={const1, 0}
+      gen
+         dcr %a
+      yields %a
+
+   from const2
+      uses reg={const1, %1.num & 0xff}
+      yields %a
+
+   from hl_or_de
+      uses reg=%1.2
+      yields %a
 
 PATTERNS
 
@@ -569,13 +624,15 @@ pat stf
          mov {m},d
 
 pat sti $1==1
-with label areg
-   gen sta %1
-with dereg areg
-   gen stax de
-with hlreg reg
-   gen mov {m},%2
-
+   with label areg
+      gen
+         sta %1
+   with dereg areg
+      gen
+         stax %1
+   with hlreg reg
+      gen
+         mov {m}, %2
 
 pat sti $1==2
    with label hlreg

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -1875,42 +1875,11 @@ pat bra
          jmp {label,$1}
 
 pat blt
-   with const2 hl_or_de STACK
+   with hlreg dereg STACK
       uses areg
       gen
-         mov a, %2.1
-         xri {const1, 0x80}
-         mov %2.1, a
-         mov a, %2.2
-         sui {const1, %1.num & 0xff}
-         mov a, %2.1
-         sbi {const1, (%1.num >> 8) ^ 0x80}
-         jc {label, $1}
-   with hl_or_de const2 STACK
-      uses areg
-      gen
-         mov a, %1.1
-         xri {const1, 0x80}
-         mov %1.1, a
-         mvi a, {const1, %2.num & 0xff}
-         sub %1.2
-         mvi a, {const1, (%2.num >> 8) ^ 0x80}
-         sbb %1.1
-         jc {label, $1}
-   with hl_or_de hl_or_de STACK
-      uses areg
-      gen
-         mov a, %2.1
-         xri {const1, 0x80}
-         mov %2.1, a
-         mov a, %1.1
-         xri {const1, 0x80}
-         mov %1.1, a
-         mov a, %2.2
-         sub %1.2
-         mov a, %2.1
-         sbb %1.1
-         jc {label,$1}
+         Call {label, ".cmps_mag"}
+         jm {label, $1}
 
 pat bgt
    leaving
@@ -1918,42 +1887,11 @@ pat bgt
       blt $1
 
 pat bge
-   with const2 hl_or_de STACK
+   with hlreg dereg STACK
       uses areg
       gen
-         mov a, %2.1
-         xri {const1, 0x80}
-         mov %2.1, a
-         mov a, %2.2
-         sui {const1, %1.num & 0xff}
-         mov a, %2.1
-         sbi {const1, (%1.num >> 8) ^ 0x80}
-         jnc {label, $1}
-   with hl_or_de const2 STACK
-      uses areg
-      gen
-         mov a, %1.1
-         xri {const1, 0x80}
-         mov %1.1, a
-         mvi a, {const1, %2.num & 0xff}
-         sub %1.2
-         mvi a, {const1, (%2.num >> 8) ^ 0x80}
-         sbb %1.1
-         jnc {label, $1}
-   with hl_or_de hl_or_de STACK
-      uses areg
-      gen
-         mov a, %2.1
-         xri {const1, 0x80}
-         mov %2.1, a
-         mov a, %1.1
-         xri {const1, 0x80}
-         mov %1.1, a
-         mov a,%2.2
-         sub %1.2
-         mov a,%2.1
-         sbb %1.1
-         jnc {label,$1}
+         Call {label, ".cmpu_mag"}
+         jp {label, $1}
 
 pat ble
    leaving

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -1618,6 +1618,70 @@ leaving cal ".cmf4" asp 8 lfr 2
 pat cmf $1==8
 leaving cal ".cmf8" asp 16 lfr 2
 
+pat cmu zlt $1==2
+   with regpair regpair STACK
+      uses areg
+      gen
+         mov a, %2.2
+         sub %1.2
+         mov a, %2.1
+         sbb %1.1
+         jc {label, $2}
+   with const2 regpair STACK
+      uses areg
+      gen
+         mov a, %2.2
+         sbi {const1, %1.num & 0xff}
+         mov a, %2.1
+         sbi {const1, %1.num >> 8}
+         jc {label, $2}
+   with regpair const2 STACK
+      uses areg
+      gen
+         mvi a, {const1, %2.num & 0xff}
+         sub %1.2
+         mvi a, {const1, %2.num >> 8}
+         sbb %1.1
+         jc {label, $2}
+
+pat cmu zgt $1==2
+   leaving
+      exg 2
+      cmu 2
+      zlt $2
+
+pat cmu zge $1==2
+   with regpair regpair STACK
+      uses areg
+      gen
+         mov a, %2.2
+         sub %1.2
+         mov a, %2.1
+         sbb %1.1
+         jnc {label, $2}
+   with const2 regpair STACK
+      uses areg
+      gen
+         mov a, %2.2
+         sbi {const1, %1.num & 0xff}
+         mov a, %2.1
+         sbi {const1, %1.num >> 8}
+         jnc {label, $2}
+   with regpair const2 STACK
+      uses areg
+      gen
+         mvi a, {const1, %2.num & 0xff}
+         sub %1.2
+         mvi a, {const1, %2.num >> 8}
+         sbb %1.1
+         jnc {label, $2}
+
+pat cmu zle $1==2
+   leaving
+      exg 2
+      cmu 2
+      zge $2
+
 pat cmu $1==2
 with hl_or_de hl_or_de
 uses areg
@@ -1883,7 +1947,7 @@ pat blt
          #else
             Call {label, ".cmps_mag"}
          #endif
-         jm {label, $1}
+         jc {label, $1}
 
 pat bgt
    leaving
@@ -1899,7 +1963,7 @@ pat bge
          #else
             Call {label, ".cmps_mag"}
          #endif
-         jp {label, $1}
+         jnc {label, $1}
 
 pat ble
    leaving

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -173,7 +173,6 @@ MOVES
       gen
          lxi %2,%1
 
-#if 0
    from const1 to reg
       gen
          mvi %2, %1
@@ -182,7 +181,6 @@ MOVES
       gen
          mvi %2.2, %1
          mvi %2.1, {const1, 0}
-#endif
 
    from reg to regpair
       gen

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -1619,7 +1619,7 @@ pat cmf $1==8
 leaving cal ".cmf8" asp 16 lfr 2
 
 pat cmu zlt $1==2
-   with regpair regpair STACK
+   with hl_or_de hl_or_de STACK
       uses areg
       gen
          mov a, %2.2
@@ -1627,7 +1627,7 @@ pat cmu zlt $1==2
          mov a, %2.1
          sbb %1.1
          jc {label, $2}
-   with const2 regpair STACK
+   with const2 hl_or_de STACK
       uses areg
       gen
          mov a, %2.2
@@ -1635,7 +1635,7 @@ pat cmu zlt $1==2
          mov a, %2.1
          sbi {const1, %1.num >> 8}
          jc {label, $2}
-   with regpair const2 STACK
+   with hl_or_de const2 STACK
       uses areg
       gen
          mvi a, {const1, %2.num & 0xff}
@@ -1651,7 +1651,7 @@ pat cmu zgt $1==2
       zlt $2
 
 pat cmu zge $1==2
-   with regpair regpair STACK
+   with hl_or_de hl_or_de STACK
       uses areg
       gen
          mov a, %2.2
@@ -1659,7 +1659,7 @@ pat cmu zge $1==2
          mov a, %2.1
          sbb %1.1
          jnc {label, $2}
-   with const2 regpair STACK
+   with const2 hl_or_de STACK
       uses areg
       gen
          mov a, %2.2
@@ -1667,7 +1667,7 @@ pat cmu zge $1==2
          mov a, %2.1
          sbi {const1, %1.num >> 8}
          jnc {label, $2}
-   with regpair const2 STACK
+   with hl_or_de const2 STACK
       uses areg
       gen
          mvi a, {const1, %2.num & 0xff}
@@ -2026,14 +2026,14 @@ pat zlt
          pop psw
          ora a
          jm {label,$1}
-   with regpair STACK
+   with hl_or_de STACK
       gen
          mov a,%1.1
          ora a
          jm {label,$1}
 
 pat zle
-   with regpair STACK
+   with hl_or_de STACK
       uses areg
       gen
          mov a, %1.1
@@ -2045,7 +2045,7 @@ pat zle
          1:
 
 pat zeq
-   with regpair STACK
+   with hl_or_de STACK
       uses areg
       gen
          mov a,%1.1
@@ -2053,7 +2053,7 @@ pat zeq
          jz {label,$1}
 
 pat zne
-   with regpair STACK
+   with hl_or_de STACK
       uses areg
       gen
          mov a,%1.1
@@ -2066,14 +2066,14 @@ pat zge
          pop psw
          ral.
          jnc {label,$1}
-   with regpair STACK
+   with hl_or_de STACK
       gen
          mov a,%1.1
          ora a
          jp {label,$1}
 
 pat zgt
-   with regpair STACK
+   with hl_or_de STACK
       uses areg
       gen
          mov a, %1.1
@@ -2105,7 +2105,7 @@ pat lol zne
          jnz {label,$2}
 
 pat ior zeq $1==2
-   with regpair regpair STACK
+   with hl_or_de hl_or_de STACK
       uses areg
       gen
          mov a,%1.1
@@ -2115,7 +2115,7 @@ pat ior zeq $1==2
          jz {label,$2}
 
 pat ior zne $1==2
-   with regpair regpair STACK
+   with hl_or_de hl_or_de STACK
       uses areg
       gen
          mov a,%1.1
@@ -2183,14 +2183,14 @@ gen 1:
 pat asp $1==0 /* do nothing */
 
 pat asp ($1==2)
-   with regpair
+   with hl_or_de
    with STACK
       uses hlreg
       gen
          pop hl
 
 pat asp ($1==4)
-   with regpair regpair
+   with hl_or_de hl_or_de
    with STACK
       uses hlreg
       gen

--- a/mach/i80/top/table
+++ b/mach/i80/top/table
@@ -16,4 +16,7 @@ xchg : inx d : xchg          -> inx h ;
 cpi 0                        -> ora a ;
 call X : ret                 -> jmp X ;
 
+push h : lxi h, X : pop d    -> lxi d, X : xchg ;
+push d : lxi d, X : pop h    -> lxi h, X : xchg ;
+
 %%;

--- a/mach/i80/top/table
+++ b/mach/i80/top/table
@@ -19,4 +19,6 @@ call X : ret                 -> jmp X ;
 push h : lxi h, X : pop d    -> lxi d, X : xchg ;
 push d : lxi d, X : pop h    -> lxi h, X : xchg ;
 
+push h : lhld h, X : pop d    -> xchg : lhld X ;
+
 %%;


### PR DESCRIPTION
This applies a number of code optimisations, mostly involved round helper routines for signed comparisons and allocating a rst to call them. Interestingly, it turns out that using a rst for unsigned comparisons is barely worth it (a handful of bytes per program) due to marshalling overhead.

Star Trek goes from 40452 to 39375 bytes.