### PR TITLE
i80: a few more minor fixes

### DIFF
--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -1687,7 +1687,7 @@ pat cmu zlt $1==2
       uses areg
       gen
          mov a, %2.2
-         sbi {const1, %1.num & 0xff}
+         sui {const1, %1.num & 0xff}
          mov a, %2.1
          sbi {const1, %1.num >> 8}
          jc {label, $2}
@@ -1719,7 +1719,7 @@ pat cmu zge $1==2
       uses areg
       gen
          mov a, %2.2
-         sbi {const1, %1.num & 0xff}
+         sui {const1, %1.num & 0xff}
          mov a, %2.1
          sbi {const1, %1.num >> 8}
          jnc {label, $2}

--- a/mach/i80/top/table
+++ b/mach/i80/top/table
@@ -13,12 +13,17 @@ mvi X, Y : mov X, Z          -> mov X, Z ;
 xchg : inx h : xchg          -> inx d ;
 xchg : inx d : xchg          -> inx h ;
 
+adi 0                        -> xra a ;
+ori 0                        -> ora a ;
+xri 0                        -> ora a ;
+adi 0                        -> ora a ;
+sui 0                        -> ora a ;
 cpi 0                        -> ora a ;
 call X : ret                 -> jmp X ;
 
 push h : lxi h, X : pop d    -> lxi d, X : xchg ;
 push d : lxi d, X : pop h    -> lxi h, X : xchg ;
 
-push h : lhld h, X : pop d    -> xchg : lhld X ;
+push h : lhld X : pop d      -> xchg : lhld X ;
 
 %%;

--- a/tests/plat/core/cmu_e.e
+++ b/tests/plat/core/cmu_e.e
@@ -16,6 +16,8 @@ zero
     rom 0
 one
     rom 1
+twofivesix
+    rom 256
 big
     #if EM_WSIZE == 2
         rom 32767
@@ -106,6 +108,19 @@ big
     cal $fail
     asp EM_WSIZE
 7
+
+    /* Test case: twofixsix < 256 */
+
+    loe twofivesix
+    loc 256
+    cmu EM_WSIZE
+    zlt *8
+    bra *9
+8
+    loc __LINE__
+    cal $fail
+    asp EM_WSIZE
+9
 
     cal $finished
     end


### PR DESCRIPTION
Silly typo fix, and an equally silly little optimisation. Star Trek goes from 39375 to 39358 bytes.