### PR TITLE
Include headers to declare functions

### DIFF
--- a/mach/pdp/cv/cv.c
+++ b/mach/pdp/cv/cv.c
@@ -10,6 +10,8 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 struct exec {
 	short a_magic;
@@ -28,6 +30,7 @@ struct  nlist
 	short           n_value; 
 };
 
+#include <object.h>
 #include <out.h>
 
 #ifndef NORCSID
@@ -164,14 +167,14 @@ main(argc, argv)
 	}
 
 	/* Action at last */
-	wr_int2(e->a_magic);
-	wr_int2(e->a_text);
-	wr_int2(e->a_data);
-	wr_int2(e->a_bss);
-	wr_int2(e->a_syms);
-	wr_int2(e->a_entry);
-	wr_int2(e->a_unused);
-	wr_int2(e->a_flag);
+	cv_int2(e->a_magic);
+	cv_int2(e->a_text);
+	cv_int2(e->a_data);
+	cv_int2(e->a_bss);
+	cv_int2(e->a_syms);
+	cv_int2(e->a_entry);
+	cv_int2(e->a_unused);
+	cv_int2(e->a_flag);
 	emits(&outsect[TEXTSG]) ;
 	emits(&outsect[ROMSG]) ;
 	emits(&outsect[DATASG]) ;
@@ -180,14 +183,14 @@ main(argc, argv)
 	return 0;
 }
 
-wr_int2(n)
+cv_int2(n)
 {
 	putc(n, output);
 	putc((n>>8), output);
 }
 
 /*
-wr_long(l)
+cv_long(l)
 	long l;
 {
 	putc((int)(l >> 16), output);
@@ -231,7 +234,6 @@ emit_symtab()
 	struct nlist PDP_name;	  /* symbol table entry in PDP V7 format */
 	register unsigned short i;
 
-	extern char *malloc();
 	char *chars;
 	long l;
 	long off = OFF_CHAR(outhead);
@@ -289,8 +291,8 @@ emit_symtab()
 			PDP_name.n_name[j] = 0;
 		}
 		fwrite((char *) &PDP_name, sizeof(char), 8, output);
-		wr_int2(PDP_name.n_type);
-		wr_int2(PDP_name.n_value);
+		cv_int2(PDP_name.n_type);
+		cv_int2(PDP_name.n_value);
 	}
 }
 

--- a/modules/src/object/object.h
+++ b/modules/src/object/object.h
@@ -9,6 +9,7 @@
 
 struct ar_hdr;
 struct outhead;
+struct outname;
 struct outrelo;
 struct outsect;
 struct ranlib;

--- a/modules/src/system/access.c
+++ b/modules/src/system/access.c
@@ -4,6 +4,7 @@
  */
 /* $Id$ */
 
+#include <unistd.h>
 #include "system.h"
 
 int

--- a/modules/src/system/close.c
+++ b/modules/src/system/close.c
@@ -4,6 +4,7 @@
  */
 /* $Id$ */
 
+#include <unistd.h>
 #include "system.h"
 
 void

--- a/modules/src/system/create.c
+++ b/modules/src/system/create.c
@@ -4,6 +4,7 @@
  */
 /* $Id$ */
 
+#include <fcntl.h>
 #include "system.h"
 
 extern File *_get_entry();
@@ -14,7 +15,7 @@ sys_create(filep, path, mode)
 	char *path;
 	int mode;
 {
-	register fd;
+	register int fd;
 	register File *fp;
 
 	if ((fp = _get_entry()) == (File *)0)

--- a/modules/src/system/open.c
+++ b/modules/src/system/open.c
@@ -4,6 +4,7 @@
  */
 /* $Id$ */
 
+#include <fcntl.h>
 #include <unistd.h>
 #include "system.h"
 

--- a/modules/src/system/open.c
+++ b/modules/src/system/open.c
@@ -4,6 +4,7 @@
  */
 /* $Id$ */
 
+#include <unistd.h>
 #include "system.h"
 
 extern File *_get_entry();
@@ -16,7 +17,6 @@ sys_open(path, flag, filep)
 {
 	register int fd;
 	register File *fp;
-	long lseek();
 
 	if ((fp = _get_entry()) == (File *)0)
 		return 0;

--- a/modules/src/system/read.c
+++ b/modules/src/system/read.c
@@ -4,6 +4,7 @@
  */
 /* $Id$ */
 
+#include <unistd.h>
 #include "system.h"
 
 int

--- a/modules/src/system/seek.c
+++ b/modules/src/system/seek.c
@@ -4,9 +4,8 @@
  */
 /* $Id$ */
 
+#include <unistd.h>
 #include "system.h"
-
-long lseek();
 
 int
 sys_seek(fp, off, whence, poff)

--- a/plat/cpm/emu/fileio.c
+++ b/plat/cpm/emu/fileio.c
@@ -1,5 +1,4 @@
-#define _XOPEN_SOURCE 500
-#define _POSIX_C_SOURCE 200809
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/plat/osx/cvmach/cvmach.c
+++ b/plat/osx/cvmach/cvmach.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <out.h>
 #include <object.h>

--- a/util/ack/files.c
+++ b/util/ack/files.c
@@ -6,6 +6,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include "ack.h"
 #include "list.h"
 #include "trans.h"

--- a/util/ack/main.c
+++ b/util/ack/main.c
@@ -4,9 +4,11 @@
  *
  */
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include "ack.h"
 #include "list.h"
 #include "trans.h"
@@ -386,7 +388,7 @@ static int process(char* arg)
 			if (linker)
 				add_input(&orig, linker);
 			return 1;
-		case F_OK:
+		case F_TRANSFORM:
 			break;
 	}
 	if (!phase)
@@ -555,7 +557,7 @@ static void setneeds(const char* suffix, int tail)
 	p_suffix = suffix;
 	switch (getpath(&phase))
 	{
-		case F_OK:
+		case F_TRANSFORM:
 			for (; phase; phase = phase->t_next)
 			{
 				if (phase->t_needed)

--- a/util/ack/run.c
+++ b/util/ack/run.c
@@ -4,9 +4,11 @@
  *
  */
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include "ack.h"
 #include "list.h"
 #include "trans.h"

--- a/util/ack/scan.c
+++ b/util/ack/scan.c
@@ -237,7 +237,7 @@ static enum f_path scan_end(trf **first) {    /* Finalization */
 				*first= curr ;
 			}
 			if ( curr->t_next ) {
-				return F_OK ;
+				return F_TRANSFORM ;
 			}
 			prev=curr ;
 		}
@@ -249,7 +249,7 @@ static enum f_path scan_end(trf **first) {    /* Finalization */
 	if ( prev ) {
 		prev->t_keep=YES ;
 	}
-	return F_OK ;
+	return F_TRANSFORM ;
 }
 
 static void find_cpp(void) {

--- a/util/ack/trans.h
+++ b/util/ack/trans.h
@@ -57,7 +57,7 @@ void add_input(path *, trf *);
 int runphase(trf *);
 
 /* scan.c */
-enum f_path { F_OK, F_NOMATCH, F_NOPATH } ;
+enum f_path { F_TRANSFORM, F_NOMATCH, F_NOPATH } ;
 enum f_path getpath(trf **);
 
 /* trans.c */

--- a/util/amisc/aelflod.c
+++ b/util/amisc/aelflod.c
@@ -24,6 +24,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <inttypes.h>
+#include <unistd.h>
 #include "out.h"
 
 #define ASSERT(x) switch (2) { case 0: case (x): ; }

--- a/util/amisc/anm.c
+++ b/util/amisc/anm.c
@@ -10,11 +10,14 @@
 **	anm [-gopruns] [name ...]
 */
 
+#include	<fcntl.h>
 #include	<stdio.h>
 #include	<stdlib.h>
 #include    <string.h>
 #include	<ctype.h>
+#include	<unistd.h>
 
+#include	"object.h"
 #include	"out.h"
 #include	"arch.h"
 #include	"ranlib.h"

--- a/util/amisc/ashow.c
+++ b/util/amisc/ashow.c
@@ -7,6 +7,7 @@ static char	rcsid[] = "$Id$";
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <object.h>
 #include <out.h>
 
 #define OK	0	/* Return value of gethead if Orl Korekt. */

--- a/util/amisc/asize.c
+++ b/util/amisc/asize.c
@@ -6,6 +6,7 @@
 
 #include	<stdlib.h>
 #include	<stdio.h>
+#include	"object.h"
 #include 	"out.h"
 
 /*

--- a/util/amisc/astrip.c
+++ b/util/amisc/astrip.c
@@ -4,9 +4,12 @@
  */
 /* $Id$ */
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <signal.h>
+#include <unistd.h>
+#include "object.h"
 #include "out.h"
 
 /*

--- a/util/arch/archiver.c
+++ b/util/arch/archiver.c
@@ -25,6 +25,7 @@ static char RcsId[] = "$Id$";
 #endif
  */
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -32,6 +33,7 @@ static char RcsId[] = "$Id$";
 #include <sys/stat.h>
 #include <signal.h>
 #include <arch.h>
+#include <object.h>
 #include <ranlib.h>
 #include <unistd.h>
 #ifdef AAL
@@ -460,7 +462,7 @@ char *mess;
 	return;
   }
   else if (u_fl && status.st_mtime <= member.ar_date) {
-	wr_arhdr(fd, member);
+	wr_arhdr(fd, &member);
 	copy_member(member, ar_fd, fd, 0);
 	return;
   }

--- a/util/cmisc/objectify.c
+++ b/util/cmisc/objectify.c
@@ -26,7 +26,7 @@ int main(int argc, const char* argv[])
 		count++;
 	}
 	printf("\n};\n");
-	printf("const size_t %s_len = %d;\n", argv[1], count);
+	printf("const size_t %s_len = %zu;\n", argv[1], count);
 
 	return 0;
 }

--- a/util/int/io.c
+++ b/util/int/io.c
@@ -4,8 +4,10 @@
 
 /* $Id$ */
 
+#include	<fcntl.h>
 #include	<stdio.h>
 #include	<stdarg.h>
+#include	<unistd.h>
 
 #include	"logging.h"
 #include	"global.h"

--- a/util/led/archive.c
+++ b/util/led/archive.c
@@ -11,6 +11,7 @@ static char rcsid[] = "$Id$";
 #include <stdint.h>
 #include <stdbool.h>
 #include "arch.h"
+#include "object.h"
 #include "out.h"
 #include "ranlib.h"
 #include "const.h"

--- a/util/led/error.c
+++ b/util/led/error.c
@@ -11,6 +11,7 @@ static char rcsid[] = "$Id$";
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdarg.h>
+#include <unistd.h>
 #include <out.h>
 #include "const.h"
 

--- a/util/led/finish.c
+++ b/util/led/finish.c
@@ -10,6 +10,7 @@ static char rcsid[] = "$Id$";
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <object.h>
 #include <out.h>
 #include "const.h"
 #include "defs.h"

--- a/util/led/output.c
+++ b/util/led/output.c
@@ -10,6 +10,7 @@ static char rcsid[] = "$Id$";
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <object.h>
 #include <out.h>
 #include "const.h"
 #include "memory.h"

--- a/util/led/write.c
+++ b/util/led/write.c
@@ -12,6 +12,7 @@ static char rcsid[] = "$Id$";
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <object.h>
 #include "out.h"
 #include "const.h"
 #include "memory.h"

--- a/util/ncgg/output.c
+++ b/util/ncgg/output.c
@@ -23,6 +23,7 @@ static char rcsid[]= "$Id$";
 #include <assert.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <unistd.h>
 #include "varinfo.h"
 #include "param.h"
 #include "reg.h"

--- a/util/opt/cleanup.c
+++ b/util/opt/cleanup.c
@@ -4,6 +4,7 @@ static char rcsid[] = "$Id$";
 
 #include <assert.h>
 #include <stdio.h>
+#include <unistd.h>
 #include "param.h"
 #include "types.h"
 #include <em_pseu.h>

--- a/util/topgen/main.c
+++ b/util/topgen/main.c
@@ -11,6 +11,7 @@
  
 #include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 #include "Lpars.h"
 
 extern int lineno, newline;


### PR DESCRIPTION
bec236c unbreaks my build on OpenBSD; `long lseek()` was wrong. The other commits just reduce warnings from clang. Most of them add #include lines to declare functions like unlink() and rd_arhdr().

84f65f7 edits plat/cpm/emu/fileio.c. @davidgiven, you have another copy of this file at [cowgol/emu/cpm/fileio.c](https://github.com/davidgiven/cowgol/blob/master/emu/cpm/fileio.c); I don't know if it needs the same edit.