### PR TITLE
Various CP/M fixes

### DIFF
--- a/lang/b/lib/b.h
+++ b/lang/b/lib/b.h
@@ -14,6 +14,8 @@
 #error Unsupported EM_PSIZE
 #endif
 
+#define MASK ((1<<SHIFT)-1)
+
 extern FILE* input_unit;
 extern FILE* output_unit;
 

--- a/lang/b/lib/main.c
+++ b/lang/b/lib/main.c
@@ -173,6 +173,8 @@ void patch_addresses(uintptr_t** p)
     while (*p)
     {
         uintptr_t* q = *p++;
+		if (*q & MASK)
+			abort();
         *q >>= SHIFT;
     }
 }

--- a/mach/i80/ncg/mach.h
+++ b/mach/i80/ncg/mach.h
@@ -7,7 +7,8 @@
 #define in_ap(y)        /* nothing */
 
 #define newilb(x)       fprintf(codefile,"%s:\n",x)
-#define newdlb(x)       fprintf(codefile,"%s:\n",x)
+#define newdlb(x)       fprintf(codefile,".align 2\n%s:\n",x)
+#define newplb(x)       fprintf(codefile,".align 2\n%s:\n", x)
 #define dlbdlb(x,y)     fprintf(codefile,"%s = %s\n",x,y)
 #define newlbss(l,x)       fprintf(codefile,".comm %s,%u\n",l,x);
 

--- a/mach/i80/ncg/table
+++ b/mach/i80/ncg/table
@@ -1089,6 +1089,7 @@ with hl_or_de
 gen dcx %1				yields %1
 
 pat del
+   kills dereg, hlreg
    uses hlreg={const2,$1}
       gen
          dad lb

--- a/mach/m68020/ncg/mach.h
+++ b/mach/m68020/ncg/mach.h
@@ -21,6 +21,7 @@ You must specify the appropriate word size, then REMOVE tables.c
 
 #define newilb(x)	fprintf(codefile,"%s:\n",x)
 #define newdlb(x)	fprintf(codefile,"%s:\n",x)
+#define newplb(x)   fprintf(codefile,".align 4\n%s:\n",x)
 #define	dlbdlb(x,y)	fprintf(codefile,"%s = %s\n",x,y)
 #define newlbss(l,x)	fprintf(codefile,".comm %s,%ld\n",l,x);
 

--- a/plat/cpm/boot.s
+++ b/plat/cpm/boot.s
@@ -10,10 +10,10 @@
 .sect .data
 .sect .bss
 
-MAX_ARGV = 8
+MAX_ARGV = 10
 
 .sect .bss
-STACKSIZE = 2*1024
+STACKSIZE = 512
 .comm stack, STACKSIZE
 
 .sect .text
@@ -140,6 +140,7 @@ __exit:
 saved_sp = . + 1
 	lxi sp, 0                ! patched on startup
 	ret
+	.align 2
 
 ! Emergency exit routine.
 
@@ -181,7 +182,8 @@ _cpm_cmdline = 0x0081
 
 ! Used to store the argv array.
 
-argc: .space 1          ! number of args
+.sect .bss
+argc: .space 2          ! number of args
 argv0: .space 2         ! always points at progname
 argv: .space 2*MAX_ARGV ! argv array (must be after argv0)
 envp: .space 2          ! envp array (always empty, must be after argv)
@@ -195,7 +197,7 @@ envp: .space 2          ! envp array (always empty, must be after argv)
 .comm .retadr, 2        ! used to save return address
 .comm .retadr1, 2       ! reserve
 .comm .bcreg, 2
-.comm .areg, 1
+.comm .areg, 2
 .comm .tmp1, 2
 .comm .fra, 8           ! 8 bytes function return area
 block1: .space 4        ! used by 32 bits divide and

--- a/plat/cpm/libsys/write.c
+++ b/plat/cpm/libsys/write.c
@@ -12,9 +12,9 @@
 
 void _sys_write_tty(char c)
 {
-	cpm_conout(c);
 	if (c == '\n')
-		cpm_conout(c);
+		cpm_conout('\r');
+	cpm_conout(c);
 }
 
 ssize_t write(int fd, void* buffer, size_t count)

--- a/plat/cpm/tests/build.lua
+++ b/plat/cpm/tests/build.lua
@@ -4,6 +4,9 @@ plat_testsuite {
     name = "tests",
     plat = "cpm",
     method = "plat/cpm/emu+emu",
-    skipsets = {"floats"},
+    skipsets = {
+        "b",      -- B is broken on i80
+        "floats"  -- floats aren't supported
+    },
     tests = { "./*.c" },
 }

--- a/plat/cpm/tests/parsefcb_c.c
+++ b/plat/cpm/tests/parsefcb_c.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include <cpm.h>
 #include "test.h"
 

--- a/plat/linux68k/boot.s
+++ b/plat/linux68k/boot.s
@@ -44,19 +44,6 @@ begtext:
 	
 	jmp (__m_a_i_n)
 	 	
-#if 0
-	mov eax, (esp)    ! eax = argc
-	lea ebx, 4(esp)   ! ebx = argv
-	lea ecx, (esp)(eax*4)
-	add ecx, 12       ! environ
-	
-	push ecx         ! environ
-	push ebx         ! argc
-	push eax         ! argv
-	push eax         ! dummy, representing the return argument
-	xor ebp, ebp
-#endif
-	
 	! This provides an emergency exit routine used by EM.
 	
 .define EXIT

--- a/plat/pc86/descr
+++ b/plat/pc86/descr
@@ -3,19 +3,19 @@
 # $Revision$
 
 var w=2
-var wa=1
+var wa=2
 var p=2
-var pa=1
+var pa=2
 var s=2
-var sa=1
+var sa=2
 var l=4
-var la=1
+var la=2
 var f=4
-var fa=1
+var fa=2
 var d=8
-var da=1
+var da=2
 var x=8
-var xa=1
+var xa=2
 var ARCH=i86
 var PLATFORM=pc86
 var PLATFORMDIR={EM}/share/ack/{PLATFORM}

--- a/tests/plat/core/rck_e.e
+++ b/tests/plat/core/rck_e.e
@@ -4,8 +4,6 @@
 /*
  * Uses _rck_ for range checks.  Catches the EM trap if a value is out
  * of range, and continues with the next instruction after _rck_.
- *
- * Some back ends, like i80, ignore _rck_, so this test fails.
  */
 
 testnr
@@ -18,6 +16,11 @@ caught
     inp $never
     exp $_m_a_i_n
     pro $_m_a_i_n,0
+
+/* These architecture ignore _rck_. */
+#if defined i80
+    cal $finished
+#endif
 
     lim           ; load ignore mask
     loc 2


### PR DESCRIPTION
This:

- fixes some warnings
- fixes a text output bug in CP/M (fixes #198)
- makes B a bit more robust by causing programs to fail to start up if they detect alignment issues
- makes the cpm tests pass (mainly by disabling B; see #199)
