### PR TITLE
General CP/M cleanup and bugfix

### DIFF
--- a/examples/hilo.p
+++ b/examples/hilo.p
@@ -60,7 +60,6 @@ procedure getname;
 	begin
 		writeln;
 		writeln('Hi there! I''m written in Pascal. Before we start, what is your name?');
-		writeln;
 		readstring(name, namelen);
 		writeln;
 		write('Hello, ');

--- a/lang/cem/libcc.ansi/core/printf/doprnt.c
+++ b/lang/cem/libcc.ansi/core/printf/doprnt.c
@@ -162,7 +162,8 @@ int _doprnt(register const char* fmt, va_list ap)
 	int i, c, width, precision, zfill, flags, between_fill;
 	int nrchars = 0;
 	const char* oldfmt;
-	char *s1, buf[1025];
+	char *s1;
+	static char buf[16]; /* used to store rendered numbers */
 
 	while (c = *fmt++)
 	{

--- a/plat/cpm/emu/dis8080.c
+++ b/plat/cpm/emu/dis8080.c
@@ -167,8 +167,8 @@ static struct insn insns[0x100] =
     { "mov m, e",      NOTHING },
     { "mov m, h",      NOTHING },
     { "mov m, l",      NOTHING },
-    { "mov m, m",      NOTHING },
     { "hlt",           NOTHING },
+	{ "mov m, a",      NOTHING },
 
     /* 77-7f */
     { "mov a, b",      NOTHING },

--- a/plat/cpm/include/cpm.h
+++ b/plat/cpm/include/cpm.h
@@ -154,7 +154,7 @@ extern void cpm_bios_settrk(uint16_t track);
 extern void cpm_bios_setsec(uint16_t sector);
 extern void cpm_bios_setdma(void* dma);
 extern uint8_t cpm_bios_read(void);
-extern uint8_t cpm_bios_write(void);
+extern uint8_t cpm_bios_write(uint8_t deblock);
 extern uint8_t cpm_bios_listst(void);
 extern uint16_t cpm_bios_sectran(uint8_t* table, uint16_t sector);
 


### PR DESCRIPTION
There are a few issues:

- cpm.h has the wrong signature for cpm_bios_write()
- printf explodes the stack
- the emulator has the wrong disassembly for one instruction