### PR TITLE
Don't rely on COMMON variable linkage.

### DIFF
--- a/lang/b/compiler/b.h
+++ b/lang/b/compiler/b.h
@@ -42,27 +42,27 @@ struct	swtab {
 
 extern int wordsize;
 extern const char* modulename;
-int paramsize;
-struct	hshtab hshtab[HSHSIZ];
-int	hshused;
-int	eof;
-int	peekc;
-const char* ctab;
-struct	hshtab *bsym;
-struct	hshtab *paraml, *parame;
-int	cval;
-int	isn;
-char	symbuf[NCPS+1];
-FILE	*sbufp;
-int	stack;
-struct	tnode **cp;
-int	*space;
-int	ospace[OSSIZ];
-int	retlab;
-int	nerror;
-struct	swtab swtab[SWSIZ];
-struct	swtab *swp;
-int	deflab;
+extern int paramsize;
+extern struct	hshtab hshtab[HSHSIZ];
+extern int	hshused;
+extern int	eof;
+extern int	peekc;
+extern const char* ctab;
+extern struct	hshtab *bsym;
+extern struct	hshtab *paraml, *parame;
+extern int	cval;
+extern int	isn;
+extern char	symbuf[NCPS+1];
+extern FILE	*sbufp;
+extern int	stack;
+extern struct	tnode **cp;
+extern int	*space;
+extern int	ospace[OSSIZ];
+extern int	retlab;
+extern int	nerror;
+extern struct	swtab swtab[SWSIZ];
+extern struct	swtab *swp;
+extern int	deflab;
 extern int	contlab;
 extern int	brklab;
 
@@ -70,16 +70,16 @@ extern int opdope[];
 extern int line;
 extern int peeksym, peeksym2;
 
-void error(char *s, ...);
-void printtoken(int tok, FILE *out);
-struct tnode * block(int op, int value, struct tnode *tr1, struct tnode *tr2);
-void rcexpr(struct tnode *tr);
-void cbranch(struct tnode *t, int lab);
-void jump(int lab);
-void fnlabel(int l);
-void tonativeaddr(void);
-void fromnativeaddr(void);
-char* manglename(char* name, char prefix);
+extern void error(char *s, ...);
+extern void printtoken(int tok, FILE *out);
+extern struct tnode * block(int op, int value, struct tnode *tr1, struct tnode *tr2);
+extern void rcexpr(struct tnode *tr);
+extern void cbranch(struct tnode *t, int lab);
+extern void jump(int lab);
+extern void fnlabel(int l);
+extern void tonativeaddr(void);
+extern void fromnativeaddr(void);
+extern char* manglename(char* name, char prefix);
 
 #define	EOFC	0
 #define	SEMI	1

--- a/lang/b/compiler/b0.c
+++ b/lang/b/compiler/b0.c
@@ -19,6 +19,35 @@ int bsymb_part;
 int code_part;
 int string_part;
 
+int paramsize;
+struct	hshtab hshtab[HSHSIZ];
+int	hshused;
+int	eof;
+int	peekc;
+const char* ctab;
+struct	hshtab *bsym;
+struct	hshtab *paraml, *parame;
+int	cval;
+int	isn;
+char	symbuf[NCPS+1];
+FILE	*sbufp;
+int	stack;
+struct	tnode **cp;
+int	*space;
+int	ospace[OSSIZ];
+int	retlab;
+int	nerror;
+struct	swtab swtab[SWSIZ];
+struct	swtab *swp;
+int	deflab;
+int	contlab;
+int	brklab;
+
+int opdope[];
+int line;
+int peeksym, peeksym2;
+
+
 void
 init(char *s, int val)
 {

--- a/util/ego/lv/lv.c
+++ b/util/ego/lv/lv.c
@@ -35,7 +35,6 @@
 #define oldlvbx(x)	oldstruct(bext_lv,x)
 
 
-short nrglobals;
 short nrvars;
 
 STATIC int Slv;

--- a/util/ego/ud/ud.c
+++ b/util/ego/ud/ud.c
@@ -33,7 +33,6 @@
 #define newudbx()	(bext_p) newstruct(bext_ud)
 #define oldudbx(x)	oldstruct(bext_ud,x)
 
-short nrglobals;
 short nrvars;
 
 int Svalue,Svariable;


### PR DESCRIPTION
I believe that support for these may have been dropped in recent gccs --- the ACK has stopped building on my system with gcc (Debian 10.2.0-6) 10.2.0. It's easiest just to change the code not to rely on them.