### PR TITLE
Add .seek asm pseudo-op, advances location counter to fixed offset

### DIFF
--- a/mach/proto/as/comm0.h
+++ b/mach/proto/as/comm0.h
@@ -226,6 +226,7 @@ typedef	struct sect_t	sect_t;
 
 /* s_flag bits: */
 #define	BASED		1	/* at fixed position */
+#define	SOUGHT		2	/* did a .seek in the section */
 
 /* sflag bits: */
 #define	SYM_EXT		001	/* external symbols */

--- a/mach/proto/as/comm2.y
+++ b/mach/proto/as/comm2.y
@@ -59,6 +59,7 @@ static item_t	*last_it, *o_it;
 %token ALIGN
 %token ASSERT
 %token SPACE
+%token SEEK
 %token <y_word> LINE
 %token FILe
 %token <y_word> LIST
@@ -251,6 +252,16 @@ operation
 					nosect();
 				DOTVAL += $2;
 				DOTSCT->s_zero += $2;
+			}
+	|	SEEK absexp
+			{	if (DOTSCT == NULL)
+					nosect();
+				if ($2 < DOTVAL)
+					serror("cannot move location counter backwards");
+				if (pass == PASS_1)
+					DOTSCT->s_flag |= SOUGHT;
+				DOTSCT->s_zero += $2 - DOTVAL;
+				DOTVAL = $2;
 			}
 	|	DATA datalist
 	|	DATA8 data8list

--- a/mach/proto/as/comm3.c
+++ b/mach/proto/as/comm3.c
@@ -37,6 +37,7 @@ item_t	keytab[] = {
 	{0,	ALIGN,		0,		".align"},
 	{0,	ASSERT,		0,		".assert"},
 	{0,	SPACE,		0,		".space"},
+	{0,	SEEK,		0,		".seek"},
 	{0,	COMMON,		0,		".comm"},
 	{0,	SECTION,	0,		".sect"},
 	{0,	BASE,		0,		".base"},

--- a/mach/proto/as/comm6.c
+++ b/mach/proto/as/comm6.c
@@ -142,6 +142,8 @@ newbase(valu_t base)
 		nosect();
 	if (sp->s_flag & BASED)
 		serror("already based");
+	if (sp->s_flag & SOUGHT)
+		serror("cannot rebase section after a seek");
 	sp->s_base = base;
 	sp->s_flag |= BASED;
 	DOTVAL += base;

--- a/man/uni_ass.6
+++ b/man/uni_ass.6
@@ -234,6 +234,9 @@ The default is the word-size of the target machine.
 .Pu ".space \fIexpression\fP"
 Allocate the indicated amount of bytes.
 The expression must be absolute.
+.Pu ".seek \fIexpression\fP"
+Advance the current position to the value of the expression.
+The expression must be absolute.
 .Pu ".comm \fIname\fP,\fIexpression\fP"
 Allocate the indicated amount of bytes and assign the location of the first
 byte allocated to
@@ -248,9 +251,8 @@ is extern, then assemblers leave definition of
 to the linkeditor \fIled\fP(1).
 .Pu .sect \fIname\fP
 section name definition.
-.Pu ".base \fIexpresssion\fP"
-Set the starting address of the first of the consecutive segments 
-(text) to the value of the expression.
+.Pu ".base \fIexpression\fP"
+Set the starting address of the current section to the value of the expression.
 The expression must be absolute.
 .Pu .assert \fIexpression\fP
 assembly-time assertion checking. Stop with a fatal error message when

--- a/plat/pc86/boot.s
+++ b/plat/pc86/boot.s
@@ -12,19 +12,6 @@
 
 .sect .text
 
-! ****** WARNING! ******
-!
-! The PC boot sector requires a magic number at the end to signify that the
-! disk is bootable. Unfortunately, the ACK assembler is a bit simple and we
-! can't tell it to put the 0xAA55 at a particular address without writing our
-! own custom binary generator. As a result, we need to manually insert just
-! the right amount of padding in order to make this work.
-!
-! If you ever need to change the boot code, this needs adjusting. I recommend
-! a hex editor.
-
-PADDING = 0xB3
-
 ! Some definitions.
 
 BOOT_SEGMENT = 0x07C0        ! Where we've been loaded
@@ -317,7 +304,7 @@ exename: .asciz 'pc86.img'
 
 	! ...and we need this to fool the PC into booting our boot sector.
 	
-	.space PADDING
+	.seek 0x1FE
 	.data2 0xAA55
 
 ! Define symbols at the beginning of our various segments, so that we can find


### PR DESCRIPTION
The new `.seek` assembler pseudo-op advances the location counter to a fixed offset within a section --- or to a fixed address, if the section is a `.base`'d section.  It works somewhat like the GNU assembler's `.org` pseudo-op, though with a hopefully less confusing name.

This pseudo-op lets us avoid having to manually compute the needed boot sector padding in the pc86 start-up code `plat/pc86/boot.s`.