### PR TITLE
Install man pages from man/ directory to staging area $(INSDIR).

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -44,6 +44,7 @@ installable {
 		"util/led+pkg",
 		"util/misc+pkg",
 		"util/opt+pkg",
+		"man+pkg",
 	},
 }
 

--- a/man/build.lua
+++ b/man/build.lua
@@ -1,0 +1,35 @@
+local installmap = {}
+
+local function build_man(name, sect)
+	-- TODO: figure out if the ./head file is really useful.  -- tkchia
+	local man = name.."."..sect
+
+	installmap["$(INSDIR)/share/man/man"..sect.."/"..man] = "./"..man
+end
+
+build_man("6500_as", "6")
+build_man("6800_as", "6")
+build_man("6805_as", "6")
+build_man("6809_as", "6")
+build_man("em_cg", "6")
+build_man("em_ncg", "6")
+build_man("i386_as", "6")
+build_man("i80_as", "6")
+build_man("i86_as", "6")
+build_man("m68020_as", "6")
+build_man("ns_as", "6")
+build_man("pdp_as", "6")
+build_man("powerpc_as", "6")
+build_man("uni_ass", "6")
+build_man("vc4_as", "6")
+build_man("z8000_as", "6")
+build_man("z80_as", "6")
+
+build_man("libmon", "7")
+build_man("libpc", "7")
+build_man("pc_prlib", "7")
+
+installable {
+	name = "pkg",
+	map = installmap
+}


### PR DESCRIPTION
This patch causes a top-level `make` and `make install` to install the `man/` directory's man pages.  These were previously not installed.

For now, the patch just copies `man/*.6` and `man/*.7` to the installation staging directory `$(INSDIR)`, and later the `$(PREFIX)` directory.

(According to `man/proto.make` and `bin/mk_manpage`, by right (?), one should prepend the file `man/head` to each `*.6` or `*.7` file.  However, on my system, prepending `man/head` does not seem to do anything useful to the final formatted outputs.)