### PR TITLE
Add unlink(2) implementation for CP/M.

### DIFF
--- a/plat/cpm/libsys/unlink.c
+++ b/plat/cpm/libsys/unlink.c
@@ -1,0 +1,39 @@
+#include <errno.h>
+#include <unistd.h>
+#include <cpm.h>
+#include "cpmsys.h"
+
+int unlink(const char* path)
+{
+	uint8_t fd = 0;
+	struct FCBE* fcbe = &__fd[0];
+	uint8_t olduser;
+
+	__init_file_descriptors();
+	while (fd != NUM_FILE_DESCRIPTORS)
+	{
+		if (fcbe->fcb.f[0] == 0)
+			break;
+		fd++;
+		fcbe++;
+	}
+	if (fd == NUM_FILE_DESCRIPTORS)
+	{
+		errno = EMFILE;
+		return -1;
+	}
+
+	fcbe->user = cpm_parse_filename(&fcbe->fcb, path);
+
+	olduser = cpm_get_user();
+	cpm_set_user(fcbe->user);
+
+	if (cpm_delete_file(&fcbe->fcb) == 0xff)
+	{
+		fcbe->fcb.f[0] = 0;
+		errno = EIO;
+		return -1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Hello --

When compiling C code for CP/M, unlink is accepted by the compiler via the unistd.h header but then fails when linking due to an undefined reference for _unlink.

This PR adds an unlink implementation for CP/M.

I am not 100% sure the errno = EIO is the correct errno for when cpm_delete_file returns 0xff, but this is good enough for my needs.

Thanks!