### PR TITLE
mach/i86/libem/csb4.s: fix incorrect i86 code for switch (long)

### DIFF
--- a/mach/i86/libem/csb4.s
+++ b/mach/i86/libem/csb4.s
@@ -16,7 +16,7 @@
 	jne     1b
 	cmp	dx,2(bx)
 	jne     1b
-	pop	bx
+	pop	cx
 	mov	bx,4(bx)
 2:
 	test    bx,bx


### PR DESCRIPTION
Fixes https://github.com/davidgiven/ack/issues/240