### PR TITLE
Add fork, wait, waitpid for all Linux targets, & execl for linux386.

### DIFF
--- a/plat/linux/include/build.lua
+++ b/plat/linux/include/build.lua
@@ -13,6 +13,7 @@ addheader("ack/fcntl.h")
 addheader("ack/signal.h")
 addheader("sys/ioctl.h")
 addheader("sys/types.h")
+addheader("sys/wait.h")
 
 
 acklibrary {

--- a/plat/linux/include/sys/wait.h
+++ b/plat/linux/include/sys/wait.h
@@ -1,0 +1,19 @@
+#ifndef _SYS_WAIT_H
+#define _SYS_WAIT_H
+
+#include <sys/types.h>
+
+extern pid_t wait(int *__wstatus);
+extern pid_t waitpid(pid_t __pid, int *__wstatus, int __options);
+
+#define WNOHANG		(1 <<  0)
+#define WUNTRACED	(1 <<  1)
+#define WSTOPPED	WUNTRACED
+#define WEXITED		(1 <<  2)
+#define WCONTINUED	(1 <<  3)
+#define WNOWAIT		(1 << 24)
+#define __WNOTHREAD	(1 << 29)
+#define __WALL		(1 << 30)
+#define __WCLONE	(1 << 31)
+
+#endif

--- a/plat/linux/libsys/fork.c
+++ b/plat/linux/libsys/fork.c
@@ -1,0 +1,8 @@
+#include <sys/types.h>
+#include <unistd.h>
+#include "libsys.h"
+
+pid_t fork(void)
+{
+	return (pid_t) _syscall(__NR_fork, 0, 0, 0);
+}

--- a/plat/linux/libsys/wait.c
+++ b/plat/linux/libsys/wait.c
@@ -1,0 +1,7 @@
+#include <sys/wait.h>
+#include "libsys.h"
+
+pid_t wait(int *wstatus)
+{
+	return (pid_t) _syscall(__NR_waitpid, -1, (quad) wstatus, 0);
+}

--- a/plat/linux/libsys/waitpid.c
+++ b/plat/linux/libsys/waitpid.c
@@ -1,0 +1,7 @@
+#include <sys/wait.h>
+#include "libsys.h"
+
+pid_t waitpid(pid_t pid, int *wstatus, int options)
+{
+	return (pid_t) _syscall(__NR_waitpid, pid, (quad) wstatus, options);
+}

--- a/plat/linux386/libsys/execl.s
+++ b/plat/linux386/libsys/execl.s
@@ -1,0 +1,29 @@
+#
+! $Source$
+! $State$
+! $Revision$
+
+! Declare segments (the order is important).
+
+.sect .text
+.sect .rom
+.sect .data
+.sect .bss
+
+.sect .text
+
+__NR_execve = 11
+
+! Perform a execl by invoking Linux's execve system call.
+
+.define _execl
+
+_execl:
+	lea eax, 8(esp)
+	push (_environ)			! envp
+	push eax			! argv
+	push -4(eax)			! pathname
+	push __NR_execve
+	call __syscall
+	add esp, 16
+	ret

--- a/plat/linuxmips/libsys/build.lua
+++ b/plat/linuxmips/libsys/build.lua
@@ -7,6 +7,7 @@ acklibrary {
 		"plat/linux/libsys/close.c",
 		"plat/linux/libsys/creat.c",
 		"plat/linux/libsys/execve.c",
+		"plat/linux/libsys/fork.c",
 		"plat/linux/libsys/getpid.c",
 		"plat/linux/libsys/gettimeofday.c",
 		"plat/linux/libsys/ioctl.c",
@@ -19,6 +20,8 @@ acklibrary {
 		"plat/linux/libsys/signal.c",
 		"plat/linux/libsys/sigprocmask.c",
 		"plat/linux/libsys/unlink.c",
+		"plat/linux/libsys/wait.c",
+		"plat/linux/libsys/waitpid.c",
 		"plat/linux/libsys/write.c",
 	},
 	deps = {

--- a/plat/linuxppc/libsys/build.lua
+++ b/plat/linuxppc/libsys/build.lua
@@ -8,6 +8,7 @@ acklibrary {
 		"plat/linux/libsys/_hol0.s",
 		"plat/linux/libsys/close.c",
 		"plat/linux/libsys/creat.c",
+		"plat/linux/libsys/fork.c",
 		"plat/linux/libsys/execve.c",
 		"plat/linux/libsys/getpid.c",
 		"plat/linux/libsys/gettimeofday.c",
@@ -21,6 +22,8 @@ acklibrary {
 		-- omit signal.c
 		"plat/linux/libsys/sigprocmask.c",
 		"plat/linux/libsys/unlink.c",
+		"plat/linux/libsys/wait.c",
+		"plat/linux/libsys/waitpid.c",
 		"plat/linux/libsys/write.c",
 	},
 	deps = {


### PR DESCRIPTION
I hope to get the ACK to become self-hosting (i.e. capable of building itself) for at least some of its supported platforms, and this PR is a very small step in that direction.

The PR adds implementations of
  * `fork`, `wait`, and `waitpid` functions, for the `linux386`, `linux68k`, `linuxmips`, and `linuxppc` platforms; and
  * `execl` for `linux386` (I am not quite sure how to code it correctly for the other `linux*` targets).

`fork`, `execl`, and `wait` are used by `util/cmisc/ed.c`.

Thank you!