### PR TITLE
aal: recognize but ignore an `s` option for GNU ar compatibility

### DIFF
--- a/util/arch/archiver.c
+++ b/util/arch/archiver.c
@@ -24,6 +24,9 @@
  #ifdef DISTRIBUTION
  *    D: make distribution: use distr_time, uid=2, gid=2, mode=0644
  #endif
+ #ifdef AAL
+ *    s: ignored; for compatibility with GNU ar (says to build index table)
+ #endif
  */
 
 #include <fcntl.h>
@@ -323,6 +326,10 @@ int main(int argc, char *argv[])
 #ifdef DISTRIBUTION
 			case 'D' :
 			distr_fl = TRUE;
+			break;
+#endif
+#ifdef AAL
+		case 's':
 			break;
 #endif
 		default:


### PR DESCRIPTION
`first/build.lua` invokes the archiver `$(AR)` with the flags `cqs`.  This patch allows this to work even if `$(AR)` is `aal`.