### PR TITLE
Use more modern temp file handling.

### DIFF
--- a/h/build.lua
+++ b/h/build.lua
@@ -3,7 +3,6 @@ normalrule {
 	ins = {},
 	outleaves = { "em_path.h" },
 	commands = {
-		"echo '#define TMP_DIR \"/tmp\"' > %{outs}",
 		"echo '#define EM_DIR \"$(PREFIX)\"' >> %{outs}",
 		"echo '#define ACK_PATH \"share/ack/descr\"' >> %{outs}",
 	}

--- a/util/ack/data.c
+++ b/util/ack/data.c
@@ -39,8 +39,6 @@ int n_error = 0; /* Number of errors encountered */
 char* progname = NULL; /* The program call name */
 
 char* outfile = NULL; /* The result file e.g. a.out */
-char template[20] = {}; /* The template for temporary file
-         names */
 
 trf* linker = NULL; /* Pointer to the Loader/Linker */
 trf* cpp_trafo = NULL; /* Pointer to C-preprocessor */

--- a/util/ack/data.h
+++ b/util/ack/data.h
@@ -38,8 +38,6 @@ extern int n_error; /* Number of errors encountered */
 extern char* progname; /* The program call name */
 
 extern char* outfile; /* The result file e.g. a.out */
-extern char template[20]; /* The template for temporary file
-          names */
 
 extern trf* linker; /* Pointer to the Loader/Linker */
 extern trf* cpp_trafo; /* Pointer to C-preprocessor */

--- a/util/ack/files.c
+++ b/util/ack/files.c
@@ -26,18 +26,6 @@ static char *add_u(int part, char *ptr) {
 	return ptr+1 ;
 }
 
-static char *unique(void) {
-	/* Get the next unique part of the internal filename */
-	static int u_next = 0 ;
-	static char buf[10] ;
-	register char *ptr ;
-
-	ptr=add_u(u_next,buf) ;
-	*ptr=0 ;
-	u_next++ ;
-	return buf ;
-}
-
 int setfiles(trf *phase) {
 	/* Set the out structure according to the in structure,
 	   the transformation and some global data */
@@ -66,15 +54,16 @@ int setfiles(trf *phase) {
 	} else {
 		gr_init(&pathname) ;
 		if ( !phase->t_keep && !t_flag ) {
-			gr_cat(&pathname,TMP_DIR) ;
-			gr_cat(&pathname,"/") ;
-			gr_cat(&pathname,template) ;
-			gr_cat(&pathname,unique()) ;
+			char* tmpdir = getenv("TMPDIR");
+			if (!tmpdir)
+				tmpdir = "/tmp";
+			gr_cat(&pathname, tmpdir);
+			gr_cat(&pathname, "/Ack-XXXXXX");
+			mkstemp(pathname.gr_string);
 			out.p_keep=NO ;
 		} else {
 			if ( !p_basename ) {
 				gr_cat(&pathname,"Ack") ;
-				gr_cat(&pathname,unique()) ;
 				p_basename=keeps(gr_start(pathname)) ;
 				werror("Output written on %s%s",
 					p_basename,phase->t_out) ;

--- a/util/ack/main.c
+++ b/util/ack/main.c
@@ -83,7 +83,6 @@ int main(int argc, char** argv)
 	}
 	transini();
 	scanneeds();
-	sprintf(template, TMPNAME, getpid());
 	if (n_error && !k_flag)
 		exit(n_error);
 

--- a/util/ego/em_ego/em_ego.c
+++ b/util/ego/em_ego/em_ego.c
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <string.h>
+#include <limits.h>
 #include "em_path.h"
 #include "system.h"
 #include "print.h"
@@ -59,12 +60,10 @@ static const struct
 #define MAXARGS 1024 /* mar # of args */
 #define NTEMPS 4 /* # of temporary files; not tunable */
 
-static char tmpbase[] = TMP_DIR "/ego.XXXXXX";
-static char ddump[128] = TMP_DIR; /* data label dump file */
-static char pdump[128] = TMP_DIR; /* procedure name dump file */
-static char tmpbufs[NTEMPS * 2][128] = {
-	TMP_DIR
-};
+static char tmpbase[NAME_MAX];
+static char ddump[NAME_MAX]; /* data label dump file */
+static char pdump[NAME_MAX]; /* procedure name dump file */
+static char tmpbufs[NTEMPS * 2][NAME_MAX];
 
 static int O2phases[] = { /* Passes for -O2 */
 	CJ, BO, SP, 0
@@ -407,7 +406,15 @@ int main(int argc, char* argv[])
 		fatal("no correct -P flag given");
 	}
 
-	close(mkstemp(tmpbase));
+	{
+		char* tmpdir = getenv("TMPDIR");
+		if (!tmpdir)
+			tmpdir = "/tmp";
+		strcpy(tmpbase, tmpdir);
+		strcat(tmpbase, "/ego.XXXXXX");
+		close(mkstemp(tmpbase));
+	}
+
 	strcpy(ddump, tmpbase);
 	strcpy(pdump, tmpbase);
 	strcpy(tmpbufs[0], tmpbase);

--- a/util/ego/il/il.c
+++ b/util/ego/il/il.c
@@ -29,6 +29,7 @@
 #include "../share/get.h"
 #include "../share/put.h"
 #include "../share/go.h"
+#include <limits.h>
 
 int calnr;
 int complete_program;
@@ -36,11 +37,12 @@ calcnt_p cchead; /* call-count info of current proc */
 STATIC long space = 0;
 STATIC long total_size = 0;
 
-STATIC char cname[128] = TMP_DIR;
-STATIC char ccname[128] = TMP_DIR;
+STATIC char cname[NAME_MAX];
+STATIC char ccname[NAME_MAX];
+STATIC char cname2[NAME_MAX];
 
 /* For debugging only */
-STATIC char sname[128] = TMP_DIR;
+STATIC char sname[NAME_MAX];
 STATIC int kp_temps = 0;
 
 int Ssubst;
@@ -124,8 +126,6 @@ STATIC void pass1(const char *lnam, const char *bnam, const char *cnam)
  * Pass 2 reads the calfile and determines which calls should
  * be expanded in line. It does not use the EM text.
  */
-
-STATIC char cname2[128] = TMP_DIR;
 
 STATIC void pass2(const char *cnam, long space)
 {
@@ -331,13 +331,23 @@ char* argv[];
 {
 	struct files* files = findfiles(argc, argv);
 	FILE* f;
+	char* tmpdir = getenv("TMPDIR");
 
 	go(argc, argv, no_action, no_action, no_action, il_flags);
 	il_extptab(fproc); /* add extended data structures */
+	if (!tmpdir)
+		tmpdir = "/tmp";
+
+	strcpy(cname, tmpdir);
+	strcpy(ccname, tmpdir);
+	strcpy(sname, tmpdir);
+	strcpy(cname2, tmpdir);
+
 	strcat(cname, "/ego.i1.XXXXXX");
 	strcat(ccname, "/ego.i2.XXXXXX");
 	strcat(sname, "/ego.i3.XXXXXX");
 	strcat(cname2, "/ego.i4.XXXXXX");
+
 	close(mkstemp(cname));
 	close(mkstemp(ccname));
 	close(mkstemp(sname));


### PR DESCRIPTION
The ACK doesn't work in bazel, because the ACK uses terrible temp file generation (pid + letter, and in a bazel sandbox all the pids are the same...). This change replaces it all, hopefully, with more modern stuff based on mkstemp.