### PR TITLE
plat/msdos86: make getpid() use European MS-DOS's getpid syscall if it exists

### DIFF
--- a/plat/msdos86/libsys/getpid.s
+++ b/plat/msdos86/libsys/getpid.s
@@ -3,6 +3,18 @@
 ! $State$
 ! $Revision$
 
+! Copyright (c) 2021--2022 TK Chia
+!
+! The authors hereby grant permission to use, copy, modify, distribute,
+! and license this software and its documentation for any purpose, provided
+! that existing copyright notices are retained in all copies and that this
+! notice is included verbatim in any distributions. No written agreement,
+! license, or royalty fee is required for any of the authorized uses.
+! Modifications to this software may be copyrighted by their authors
+! and need not follow the licensing terms described here, provided that
+! the new terms are clearly indicated on the first page of each file where
+! they apply.
+
 ! Declare segments (the order is important).
 
 .sect .text
@@ -13,15 +25,21 @@
 .sect .text
 
 ! Get the current process identifier.  For MS-DOS, use the Program Segment
-! Prefix (PSP) segment as the PID.
+! Prefix (PSP) segment as the PID, unless the system supports an actual
+! `getpid' syscall, e.g. European MS-DOS 4.0.
 !
-! (Note that pid_t is a 32-bit type.  This is to allow for PSP addresses
-! above 0x7FFF:0.)
+! (Note that pid_t is a 32-bit type.  This is to allow for PSP segments and
+! MS-DOS PIDs above 0x7FFF.)
 
 .define _getpid
 _getpid:
+	movb ah, 0x87
+	stc
+	int 0x21
+	jnc .eur_dos
 	movb ah, 0x51
 	int 0x21
 	xchg bx, ax
+.eur_dos:
 	xor dx, dx
 	ret


### PR DESCRIPTION
Apparently [European MS-DOS 4.0](https://en.wikipedia.org/wiki/MS-DOS_4.0_%28multitasking%29) actually has a [`getpid` syscall](https://www.delorie.com/djgpp/doc/rbinter/id/64/32.html), which one can use to obtain a process id for the running process.

This proposed patch uses this syscall to implement the `getpid ()` function, wherever it is supported.

On most versions of MS-DOS, this syscall does not exist, and `getpid ()` can fall back on using the process's Program Segment Prefix ([PSP](https://www.delorie.com/djgpp/doc/rbinter/id/94/29.html)) segment value as the process id, as before.