### PR TITLE
cpp.ansi, em_m2: include correct prototype for sprint( ).

### DIFF
--- a/lang/cem/cpp.ansi/preprocess.c
+++ b/lang/cem/cpp.ansi/preprocess.c
@@ -22,14 +22,13 @@
 #include "error.h"
 #include "bits.h"
 #include "skip.h"
+#include "print.h"
 
 char _obuf[OBUFSIZE];
 #ifdef DOBITS
 char bits[128];
 #endif
 extern int InputLevel;
-
-extern char* sprint();
 
 void Xflush(void)
 {

--- a/lang/m2/comp/enter.c
+++ b/lang/m2/comp/enter.c
@@ -118,7 +118,6 @@ void EnterVarList(struct node *Idlist, struct type *type, int local)
 	register struct node *idlist = Idlist;
 	register struct scopelist *sc = CurrVis;
 	char buf[256];
-	extern char *sprint();
 
 	if (local) {
 		/* Find the closest enclosing open scope. This

--- a/lang/m2/comp/f_info.h
+++ b/lang/m2/comp/f_info.h
@@ -9,6 +9,8 @@
 
 /* $Id$ */
 
+#include "print.h"
+
 struct f_info {
 	unsigned short f_lineno;
 	char *f_filename;

--- a/lang/m2/comp/misc.c
+++ b/lang/m2/comp/misc.c
@@ -46,7 +46,6 @@ struct idf *gen_anon_idf(void)
 	*/
 	static int name_cnt;
 	char *s = Malloc(strlen(FileName)+50);
-	char *sprint();
 
 	sprint(s, "#%d in %s, line %u",
 			++name_cnt, FileName, LineNumber);

--- a/lang/m2/comp/program.g
+++ b/lang/m2/comp/program.g
@@ -144,7 +144,6 @@ DefinitionModule
 	int		dummy;
 	extern struct idf	*DefId;
 	extern int	ForeignFlag;
-	extern char	*sprint();
 	register struct scope *currscope = CurrentScope;
 	char buf[512];
 } :

--- a/lang/m2/comp/stab.c
+++ b/lang/m2/comp/stab.c
@@ -28,13 +28,13 @@
 #include	"error.h"
 #include	"stab.h"
 #include	"main.h"
+#include	"print.h"
 
 extern int	gdb_flag;
 
 #define INCR_SIZE	64
 
 extern int	proclevel;
-extern char	*sprint();
 
 static struct db_str {
 	unsigned	sz;

--- a/lang/m2/m2mm/f_info.h
+++ b/lang/m2/m2mm/f_info.h
@@ -9,6 +9,8 @@
 
 /* $Id$ */
 
+#include "print.h"
+
 struct f_info {
 	unsigned short f_lineno;
 	char *f_fn;

--- a/lang/m2/m2mm/misc.c
+++ b/lang/m2/m2mm/misc.c
@@ -23,7 +23,6 @@ gen_anon_idf()
 	*/
 	static int name_cnt;
 	char buff[100];
-	char *sprint();
 
 	sprint(buff, "#%d in %s, line %u",
 			++name_cnt, FileName, LineNumber);


### PR DESCRIPTION
This should mostly fix the crashes which were observed on GitHub CI (e.g. https://github.com/davidgiven/ack/actions/runs/11410639087/job/31753347141) when building ACK for a macOS host on 64-bit ARM.

It turns out that Apple's ARM64 ABI handles variable arguments in variadic functions differently from named arguments
(https://developer.apple.com/documentation/xcode/application-binary-interfaces). Thus callees which want to call the variadic function sprint( ) must declare the correct prototype, otherwise they will pass arguments to it wrongly.