### PR TITLE
Fix DOS binary file I/O always returning EOF

### DIFF
--- a/plat/msdos/libsys/read.c
+++ b/plat/msdos/libsys/read.c
@@ -77,6 +77,8 @@ ssize_t read(int fd, void* buffer, size_t count)
 				--left;
 			}
 		}
+		else
+			return r;
 	} while (tot < count && !eof && _sys_isreadyr(fd));
 
 	return tot;


### PR DESCRIPTION
Closes #365