### PR TITLE
Fix the Linux/m68k target

### DIFF
--- a/plat/linux68k/boot.s
+++ b/plat/linux68k/boot.s
@@ -1,7 +1,7 @@
 #
-! $Source: /cvsroot/tack/Ack/plat/linux386/boot.s,v $
+! $Source: /cvsroot/tack/Ack/plat/linux68k/boot.s,v $
 ! $State: Exp $
-! $Revision: 1.3 $
+! $Revision: 1.4 $
 
 ! Declare segments (the order is important).
 
@@ -18,30 +18,31 @@ begtext:
 	!
 	! On entry, the stack looks like this:
 	!
-	! sp+..            NULL
-	! sp+8+(4*argc)   env (X quads)
+	! sp+8+(4*argc)   envp[0] ...
 	! sp+4+(4*argc)   NULL
-	! sp+4            argv (argc quads)
+	! sp+4            argv[0] ... argv[argc-1]
 	! sp              argc
 	!
-	! The ACK actually expects:
-	!
-	! sp+8            argc
-	! sp+4            argv
-	! sp              env
+	! _main parameters are:
+	!   argc (word), argv (pointer), envp (pointer)
+	! sp+12           envp
+	! sp+8            argv
+	! sp+4            argc
+	! sp              return
 
-	move.l (0, sp), d0 ! d0 = argc
-	move.l (4, sp), d1 ! d1 = argv
-	move.l d0, d2
-	asl.l #2, d2
-	move.l (sp, d2), d2
-	add.l #12, d2      ! d2 = environ
-	
-	move.l d2, -(sp)   ! environ
-	move.l d0, -(sp)   ! argc
-	move.l d1, -(sp)   ! argv
-	pea (0)            ! dummy, representing the return address
-	
+	move.l (0, sp), d0      ! d0 = argc
+	lea (4, sp), a0         ! a0 = argv
+
+	move.l d0, d1
+	asl.l #2, d1            ! d1 = argc*4
+	add.l a0, d1            ! d1 = &argv[argc]
+	add.l #4, d1            ! d1 = envp
+
+	move.l d1, -(sp)        ! envp
+	move.l a0, -(sp)        ! argv
+	move.l d0, -(sp)        ! argc
+	pea (0)                 ! return
+
 	jmp (__m_a_i_n)
 	 	
 	! This provides an emergency exit routine used by EM.

--- a/plat/linux68k/libsys/_syscall.s
+++ b/plat/linux68k/libsys/_syscall.s
@@ -1,7 +1,7 @@
 #
-! $Source: /cvsroot/tack/Ack/plat/linux386/libsys/_syscall.s,v $
+! $Source: /cvsroot/tack/Ack/plat/linux68k/libsys/_syscall.s,v $
 ! $State: Exp $
-! $Revision: 1.1 $
+! $Revision: 1.2 $
 
 ! Declare segments (the order is important).
 
@@ -13,21 +13,26 @@
 .sect .text
 
 EINVAL = 22
-	
+
 ! Perform a Linux system call.
 
 .define __syscall
 __syscall:
-	move.l (4, sp), d0
-	move.l (8, sp), d1
-	move.l (12, sp), d2
-	move.l (16, sp), d3
+	move.l d2, -(sp)
+	move.l d3, -(sp)
+	! Stack: (0)saved d3, (4)saved d2, (8)ret, (12)op, (16)p1, (20)p2, (24)p3
+	move.l (12, sp), d0
+	move.l (16, sp), d1
+	move.l (20, sp), d2
+	move.l (24, sp), d3
 	trap #0
-	
+	move.l (sp)+, d3
+	move.l (sp)+, d2
+
 	tst.l d0
 	bmi 1f
 	rts
-	
+
 1:
 	neg.l d0
 	! It just so happens that errnos 1-34 are the same in Linux as in ACK.
@@ -39,7 +44,7 @@ __syscall:
 3:
 	move.l #-1, d0
 	rts
-	
+
 2:
 	move.l #EINVAL, (_errno)
 	bra 3b


### PR DESCRIPTION
1. Fixed  the Linux/m68k startup code (bad argv, swapped args, wrong env pointer).
2. Fixed `_syscall` putting args in `d2`/`d3` without saving them.

It builds https://gitlab.com/dps8m/crc.git correctly and the full CRC test suite (`make test`) now passes.

Closes #369